### PR TITLE
Improve local configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ dummy.py
 gofile.env
 *.csv
 gofile-alljs-*
+md5_speed.py

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Built using `asyncio`, `aiohttp`, and `tqdm`
 - Progress bars
 - Upload logging
 - Skipping duplicate uploads
+- Local configs
 
 ## Usage
 1. `pip install GofileIOUploader`
@@ -29,7 +30,7 @@ Gofile.io Uploader supporting parallel uploads
 positional arguments:
   file                  File or directory to look for files in to upload
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
   -t TOKEN, --token TOKEN
                         API token for your account so that you can upload to a
@@ -42,19 +43,21 @@ options:
                         name if used
   -d, --dry-run         Don't create folders or upload files
   --debug-save-js-locally, --no-debug-save-js-locally
-                        Debug option to save the retrieved js file locally
+                        Debug option to save the retrieved js file locally.
+                        (default: False)
   -c CONNECTIONS, --connections CONNECTIONS
-                        Maximum parallel uploads to do at once
+                        Maximum parallel uploads to do at once. (default: 6)
   --public, --no-public
                         Make all files uploaded public. By default they are
-                        private and not unsharable
+                        private and not unsharable. (default: False)
   --save, --no-save     Don't save uploaded file urls to a
-                        "gofile_upload_<unixtime>.csv" file
+                        "gofile_upload_<unixtime>.csv" file. (default: True)
   --use-config, --no-use-config
                         Whether to create and use a config file in
-                        $HOME/.config/gofile_upload/config.json
+                        $HOME/.config/gofile_upload/config.json. (default:
+                        True)
   -r RETRIES, --retries RETRIES
-                        How many times to retry a failed upload
+                        How many times to retry a failed upload. (default: 3)
 
 ```
 ## Details
@@ -67,6 +70,44 @@ Configs are stored in `$HOME/.config/gofile_upload/config.json` and all successf
 Each time you complete an upload a `gofile_upload_<timestamp>.csv` will be created with the items uploaded and the following metadata:
 `filePath,filePathMD5,fileNameMD5,uploadSuccess,code,downloadPage,fileId,fileName,guestToken,md5,parentFolder`
 
+### Local Configuration
+A local configuration can be used when you specify the `--use-config` flag
+This config is saved in `$HOME/.config/gofile-upload/config.json` and contains the following options:
+```json
+{
+  "token": "Optional[str]",
+  "zone": "Optional[str]",
+  "connections": "Optional[int]",
+  "public": "Optional[bool]",
+  "save": "Optional[bool]",
+  "retries": "Optional[int]",
+  "history": {
+    "md5_sums": {
+      "<filepath>": "<md5sum of file>"
+    },
+    "uploads": [
+      "<upload response>"
+    ]
+  }
+}
+```
+This config is loaded at runtime and combined with CLI options and defaults to make one config for the program.
+The precedence for this is:
+1. CLI Defaults
+   - connections: 6
+   - public: False
+   - retries: 3
+   - save: True
+   - debug_save_js_locally: False
+   - use_config: True
+2. Local Config
+3. CLI Options
+
+The config will be saved when MD5 sums are calculated for files as well as when uploads are completed.
+Configs that have a value of `None` will be omitted.
+
+If you specify `--no-use-config` the local file will not be loaded and will not be saved to.
+
 ## Examples
 Given
 ```
@@ -74,25 +115,26 @@ directory/
 ├── sample2.mkv
 └── sample.mkv
 ```
-**Upload single file anonymously**
+**Upload single file anonymously** 
+The file will be private
 
 `gofile-upload directory/sample.mkv`
 
-**Upload single file to your account**
+**Upload single file to your account and make it public**
 
-`gofile-upload --token 123 foo directory/sample.mkv`
+`gofile-upload --token 123 --public directory/sample.mkv`
 
-**Upload single file to directory `foo` in your account**
+**Upload single file to directory `foo` in your account and make it public**
 
-`gofile-upload --token 123 --folder foo directory/sample.mkv`
+`gofile-upload --token 123 --public --folder foo directory/sample.mkv`
 
-**Upload directory to your account**
+**Upload directory to your account and make them public**
 
-`gofile-upload --token 123 directory`
+`gofile-upload --token 123 --public directory`
 
-**Upload directory to directory `foo` in your account**
+**Upload directory to directory `foo` in your account and make them public**
 
-`gofile-upload --token 123 --folder foo directory`
+`gofile-upload --token 123 --public --folder foo directory`
 
 # Development
 ## Optional Prerequesites

--- a/README.md
+++ b/README.md
@@ -153,15 +153,14 @@ pre-commit install
 ```
 
 ## Packaging
-```bash
-python3 -m build
-python3 -m twine upload --skip-existing --repository pypi dist/*
-```
+This package currently uses [just](https://github.com/casey/just which is a Makefile like utility.
 
+You must install `just` first and then you can do things like `just build` or `just release` which depend on the `justfile` to take actions.
 
 # Improvements Wishlist
 - [ ] Paid accounts support, I don't have a paid account so I can't test
 - [ ] Add tests
+- [ ] Use typing-extensions
 - [ ] Add github runners for tests
 - [ ] Recursive directory upload support
 
@@ -173,3 +172,4 @@ python3 -m twine upload --skip-existing --repository pypi dist/*
 - https://github.com/rkwyu/gofile-dl
 - https://stackoverflow.com/questions/1131220/get-the-md5-hash-of-big-files-in-python
 - https://packaging.python.org/en/latest/tutorials/packaging-projects/
+- https://github.com/f-o

--- a/justfile
+++ b/justfile
@@ -1,0 +1,9 @@
+setup:
+    pip install -r requirements-dev.txt
+    pre-commit install
+
+build:
+    python3 -m build
+
+release: build
+    python3 -m twine upload --skip-existing --repository pypi dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GofileIOUploader"
-version = "0.10.3"
+version = "0.11.0"
 description = "Gofile.io uploader supporting parallel uploads"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/gofile_uploader/cli.py
+++ b/src/gofile_uploader/cli.py
@@ -1,0 +1,114 @@
+import argparse
+import json
+import logging
+import os
+from pathlib import Path
+
+from .types import GofileUploaderLocalConfigOptions, GofileUploaderOptions
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
+
+
+def load_config_file(config_file_path: Path) -> GofileUploaderLocalConfigOptions:
+    """
+    Loads the local config file, options with None values will be omitted
+    """
+    config = {}
+    if config_file_path.exists():
+        with open(config_file_path, "r") as config_file:
+            logger.debug(f"Loading config from {config_file_path}")
+            try:
+                loaded_config = json.load(config_file)
+                config = {k: v for k, v in loaded_config.items() if v is not None}
+            except Exception:
+                logger.exception(f"Failed to load config file {config_file_path} as a JSON config")
+    else:
+        logger.error(f"Could not load config file {config_file_path} because it did not exist")
+    return config
+
+
+def cli() -> GofileUploaderOptions:
+    parser = argparse.ArgumentParser(prog="gofile-upload", description="Gofile.io Uploader supporting parallel uploads")
+    parser.add_argument("file", type=Path, help="File or directory to look for files in to upload")
+    parser.add_argument(
+        "-t",
+        "--token",
+        type=str,
+        default=os.getenv("GOFILE_TOKEN"),
+        help="""API token for your account so that you can upload to a specific account/folder.
+                You can also set the GOFILE_TOKEN environment variable for this""",
+    )
+    parser.add_argument(
+        "-z",
+        "--zone",
+        type=str,
+        choices=["na", "eu"],
+        help="Server zone to prefer uploading to",
+    )
+    parser.add_argument(
+        "-f", "--folder", type=str, help="Folder to upload files to overriding the directory name if used"
+    )
+    parser.add_argument(
+        "-d",
+        "--dry-run",
+        action="store_true",
+        help="Don't create folders or upload files",
+    )
+    parser.add_argument(
+        "--debug-save-js-locally",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Debug option to save the retrieved js file locally",
+    )
+    parser.add_argument("-c", "--connections", type=int, default=6, help="Maximum parallel uploads to do at once")
+    parser.add_argument(
+        "--public",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Make all files uploaded public. By default they are private and not unsharable",
+    )
+    parser.add_argument(
+        "--save",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help='Don\'t save uploaded file urls to a "gofile_upload_<unixtime>.csv" file',
+    )
+    parser.add_argument(
+        "--use-config",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Whether to create and use a config file in $HOME/.config/gofile_upload/config.json",
+    )
+    parser.add_argument(
+        "-r",
+        "--retries",
+        default=3,
+        type=int,
+        help="How many times to retry a failed upload",
+    )
+    args = parser.parse_args()
+
+    loaded_options = {}
+
+    combined_options: GofileUploaderOptions = {"config_file_path": None, "config_directory": None}  # type: ignore
+
+    # Load any local configs
+    if args.use_config:
+        home_path = Path.home()
+        config_directory = home_path.joinpath(".config", "gofile-upload")
+        config_file_path = config_directory.joinpath("config.json")
+        # TODO: Might need to remove any keys where values are none
+        loaded_options = load_config_file(config_file_path)
+        combined_options["config_file_path"] = config_file_path
+        combined_options["config_directory"] = config_directory
+
+    # Load the CLI configs
+    cli_options = vars(args)
+
+    # Overwrite with local
+    combined_options.update(loaded_options)
+    # Overwrite with cli
+    combined_options.update(cli_options)
+
+    return combined_options

--- a/src/gofile_uploader/cli.py
+++ b/src/gofile_uploader/cli.py
@@ -106,7 +106,14 @@ def cli() -> GofileUploaderOptions:
 
     loaded_options = {}
 
-    combined_options: GofileUploaderOptions = {"config_file_path": None, "config_directory": None}  # type: ignore
+    combined_options: GofileUploaderOptions = {  # type: ignore
+        "config_file_path": None,
+        "config_directory": None,
+        "history": {
+            "md5_sums": {},
+            "uploads": [],
+        },
+    }
 
     # Load the faked CLI default options first
     combined_options.update(default_cli_options)

--- a/src/gofile_uploader/gofile_uploader.py
+++ b/src/gofile_uploader/gofile_uploader.py
@@ -5,13 +5,11 @@ import json
 import logging
 import re
 import time
-from io import BufferedReader
 from pathlib import Path
 from pprint import pformat, pprint
-from typing import Callable, Literal, Optional
+from typing import Literal, Optional
 
 import aiohttp
-from tqdm import tqdm
 from tqdm.asyncio import tqdm_asyncio
 
 from .cli import cli
@@ -26,44 +24,10 @@ from .types import (
     UpdateContentOption,
     UpdateContentOptionValue,
 )
+from .utils import ProgressFileReader, TqdmUpTo
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
-
-
-class ProgressFileReader(BufferedReader):
-    def __init__(self, filename: Path, read_callback: Optional[Callable[[int, int, Optional[int]], None]] = None):
-        # Don't use with because we need the file to be open for future progress
-        # No idea if this causes memory issues
-        f = open(filename, "rb")
-        self.__read_callback = read_callback
-        super().__init__(raw=f)
-        self.length = Path(filename).stat().st_size
-
-    def read(self, size: Optional[int] = None):
-        calc_sz = size
-        if not calc_sz:
-            calc_sz = self.length - self.tell()
-        if self.__read_callback:
-            self.__read_callback(self.tell(), round(self.tell() / self.length), self.length)
-        return super(ProgressFileReader, self).read(size)
-
-
-class TqdmUpTo(tqdm):
-    """Provides `update_to(n)` which uses `tqdm.update(delta_n)`."""
-
-    def update_to(self, b=1, bsize=1, tsize=None):
-        """
-        b  : int, optional
-            Number of blocks transferred so far [default: 1].
-        bsize  : int, optional
-            Size of each block (in tqdm units) [default: 1].
-        tsize  : int, optional
-            Total size (in tqdm units). If [default: None] remains unchanged.
-        """
-        if tsize is not None:
-            self.total = tsize
-        return self.update(b * bsize - self.n)  # also sets self.n = b * bsize
 
 
 class GofileIOAPI:

--- a/src/gofile_uploader/types.py
+++ b/src/gofile_uploader/types.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Literal, Optional, TypedDict, Union
 
 
@@ -155,3 +156,41 @@ class GofileCLIArgs(TypedDict):
 class GofileCLIDebugOptions(TypedDict):
     save_js_locally: Optional[bool]
     create_config: Optional[bool]
+
+
+# class GofileUploaderOptions(TypedDict):
+#     save_js_locally: Optional[bool]
+#     create_config: Optional[bool]
+#
+#     token: Optional[str]
+#     max_connections: Optional[int]
+#     make_public: Optional[bool]
+#     zone: Optional[str]
+#     retries: Optional[int]
+#     save: Optional[bool]
+
+
+class GofileUploaderLocalConfigHistory(TypedDict):
+    uploads: list[dict]
+    md5_sums: dict[str, str]
+
+
+class GofileUploaderLocalConfigOptions(TypedDict):
+    token: Optional[str]
+    zone: Optional[str]
+    connections: Optional[int]
+    public: Optional[bool]
+    save: Optional[bool]
+    retries: Optional[int]
+    history: GofileUploaderLocalConfigHistory
+
+
+class GofileUploaderOptions(GofileUploaderLocalConfigOptions):
+    dry_run: Optional[str]
+    debug_save_js_locally: Optional[bool]
+    use_config: Optional[bool]
+    folder: Optional[str]
+    file: Path
+    # These options are derived on runtime
+    config_file_path: Optional[Path]
+    config_directory: Optional[Path]

--- a/src/gofile_uploader/types.py
+++ b/src/gofile_uploader/types.py
@@ -158,18 +158,6 @@ class GofileCLIDebugOptions(TypedDict):
     create_config: Optional[bool]
 
 
-# class GofileUploaderOptions(TypedDict):
-#     save_js_locally: Optional[bool]
-#     create_config: Optional[bool]
-#
-#     token: Optional[str]
-#     max_connections: Optional[int]
-#     make_public: Optional[bool]
-#     zone: Optional[str]
-#     retries: Optional[int]
-#     save: Optional[bool]
-
-
 class GofileUploaderLocalConfigHistory(TypedDict):
     uploads: list[dict]
     md5_sums: dict[str, str]

--- a/src/gofile_uploader/utils.py
+++ b/src/gofile_uploader/utils.py
@@ -1,0 +1,44 @@
+from io import BufferedReader
+from pathlib import Path
+from typing import Callable, Optional
+
+from tqdm import tqdm
+
+
+def return_dict_without_none_value_keys(item: dict):
+    return {k: v for k, v in item.items() if v is not None}
+
+
+class ProgressFileReader(BufferedReader):
+    def __init__(self, filename: Path, read_callback: Optional[Callable[[int, int, Optional[int]], None]] = None):
+        # Don't use with because we need the file to be open for future progress
+        # No idea if this causes memory issues
+        f = open(filename, "rb")
+        self.__read_callback = read_callback
+        super().__init__(raw=f)
+        self.length = Path(filename).stat().st_size
+
+    def read(self, size: Optional[int] = None):
+        calc_sz = size
+        if not calc_sz:
+            calc_sz = self.length - self.tell()
+        if self.__read_callback:
+            self.__read_callback(self.tell(), round(self.tell() / self.length), self.length)
+        return super(ProgressFileReader, self).read(size)
+
+
+class TqdmUpTo(tqdm):
+    """Provides `update_to(n)` which uses `tqdm.update(delta_n)`."""
+
+    def update_to(self, b=1, bsize=1, tsize=None):
+        """
+        b  : int, optional
+            Number of blocks transferred so far [default: 1].
+        bsize  : int, optional
+            Size of each block (in tqdm units) [default: 1].
+        tsize  : int, optional
+            Total size (in tqdm units). If [default: None] remains unchanged.
+        """
+        if tsize is not None:
+            self.total = tsize
+        return self.update(b * bsize - self.n)  # also sets self.n = b * bsize


### PR DESCRIPTION
Bumps version to `0.11.0`
Increases support for local configs, see README for more details., this will likely have breaking changes so I recommend deleting `$HOME/.config/gofile-upload/config.json`
Adds justfile for use with [just](https://github.com/casey/just)
Splits up some of the code to separate files like `utils` and `cli`