### PR TITLE
Add tests, use typing-extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,52 @@ This package currently uses [just](https://github.com/casey/just which is a Make
 
 You must install `just` first and then you can do things like `just build` or `just release` which depend on the `justfile` to take actions.
 
+# Testing
+**WARNING:** Tests will use a gofile account and are destructive (they will delete all created files). 
+Do not use your regular account for tests and be careful of running tests in the same environment if a `GOFILE_TOKEN` environment variable exists.
+
+This packages uses [pytest](https://docs.pydantic.dev/latest/) and [pytest-asyncio](https://pytest-asyncio.readthedocs.io/en/latest/) for testing.
+In order to omit different pytest async decorators, pytest has its configuration setup in `pyproject.toml` to
+```
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+```
+In practice this is of little value because pytest-asyncio seems to be [a mess](https://github.com/pytest-dev/pytest-asyncio/issues/706) when working with fixtures at different scopes. 
+I've ended up setting all fixtures and tests to session based levels even when it does not make sense but at least this does work.
+
+It also makes use of [pydantic](https://docs.pytest.org) in order to try and validate that certain server responses match the TypedDicts I've setup.
+If there is a better way to do this please let me know or draft a PR.
+
+You should set the gofile token in your environment so that new accounts are not created for each test.
+This can be done via something like `export GOFILE_TOKEN=123` or your IDE.
+
+To test you can run the following from the root directory:
+```
+(venv) [alex@xyz gofile-uploader]$ pytest src/gofile_uploader
+============================ test session starts ============================
+platform linux -- Python 3.9.18, pytest-8.2.2, pluggy-1.5.0
+rootdir: /home/alex/PycharmProjects/gofile-uploader
+configfile: pyproject.toml
+plugins: asyncio-0.23.7
+asyncio: mode=auto
+collected 3 items                                                           
+
+src/gofile_uploader/tests/test_api_servers.py ..                      [ 66%]
+src/gofile_uploader/tests/test_api_wt.py .                            [100%]
+
+============================= 3 passed in 1.05s =============================
+```
+
+## Coverage
+Test coverage is also generated using [pytest-cov](https://github.com/pytest-dev/pytest-cov).
+You should disable this when debugging.
+
+
 # Improvements Wishlist
 - [ ] Paid accounts support, I don't have a paid account so I can't test
-- [ ] Add tests
-- [ ] Use typing-extensions
+- [ ] Update filenames during sync to local version
+- [ ] Add more tests
+- [ ] Create an account when the user does not do so
 - [ ] Add github runners for tests
 - [ ] Recursive directory upload support
 
@@ -173,3 +215,4 @@ You must install `just` first and then you can do things like `just build` or `j
 - https://stackoverflow.com/questions/1131220/get-the-md5-hash-of-big-files-in-python
 - https://packaging.python.org/en/latest/tutorials/packaging-projects/
 - https://github.com/f-o
+- https://stackoverflow.com/questions/66665336/validate-python-typeddict-at-runtime

--- a/justfile
+++ b/justfile
@@ -7,3 +7,10 @@ build:
 
 release: build
     python3 -m twine upload --skip-existing --repository pypi dist/*
+
+lint:
+    black -l 120 -t py39 src/
+    isort src/
+
+test:
+    pytest src/gofile_uploader/tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,21 @@ extend-exclude = '''
 [tool.isort]
 profile = "black"
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+addopts = "--cov=src/gofile_uploader -p no:warnings --cov-branch --cov-report html"
+# addopts = "--cov=src/gofile_uploader --no-cov"
+
+[tool.coverage.run]
+omit = ["src/gofile_uploader/tests/*", "__init__.py", "conftest.py"]
+
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "GofileIOUploader"
-version = "0.11.0"
+version = "0.11.1.dev1"
 description = "Gofile.io uploader supporting parallel uploads"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -39,7 +47,7 @@ classifiers = [
     "Framework :: aiohttp",
     "License :: OSI Approved :: MIT License",
     "Intended Audience :: End Users/Desktop",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: Implementation",
     "Topic :: Internet",
     "Topic :: Utilities"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,8 @@ isort
 pre-commit
 twine
 build
+typing-extensions
+pytest
+pytest-asyncio
+pydantic
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp
 tqdm
+typing-extensions

--- a/src/gofile_uploader/api.py
+++ b/src/gofile_uploader/api.py
@@ -1,0 +1,261 @@
+import asyncio
+import hashlib
+import logging
+import re
+from pathlib import Path
+from pprint import pformat
+
+import aiohttp
+from tqdm.asyncio import tqdm_asyncio
+from typing_extensions import List, Literal, Optional
+
+from .types import (
+    CompletedFileUploadResult,
+    CreateFolderResponse,
+    DeleteContentsResponse,
+    GetAccountDetailsResponse,
+    GetAccountIdResponse,
+    GetContentResponse,
+    GetNewAccountResponse,
+    GetServersResponse,
+    GofileUploaderOptions,
+    UpdateContentOption,
+    UpdateContentOptionValue,
+    UpdateContentResponse,
+)
+from .utils import ProgressFileReader, TqdmUpTo
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
+
+
+class GofileIOAPI:
+    def __init__(self, options: GofileUploaderOptions):
+        self.options = options
+        self.session_headers = (
+            {"Authorization": f"Bearer {self.options['token']}"} if self.options.get("token") else None
+        )
+        self.session = aiohttp.ClientSession("https://api.gofile.io", headers=self.session_headers)
+        # These are set once the account is queried
+        self.root_folder_id = None
+        self.account_id = None
+        self.is_premium = False
+
+        self.wt = None
+        self.server_sessions = {}
+        self.created_folders = {}
+        self.sem = asyncio.Semaphore(self.options["connections"])
+
+    async def init(self):
+        # Create an account if none was specified
+        if self.options.get("token") is None:
+            temporary_account = await GofileIOAPI.get_new_account()
+            self.options["token"] = temporary_account["data"]["token"]
+            self.account_id = temporary_account["data"]["id"]
+
+            # Recreate the API session with the new auth
+            if not self.session.closed:
+                await self.session.close()
+            self.session_headers = {"Authorization": f"Bearer {self.options['token']}"}
+            self.session = aiohttp.ClientSession("https://api.gofile.io", headers=self.session_headers)
+
+        # Use the account provided by the token
+        else:
+            account_id = await self.get_account_id()
+            self.account_id = account_id["data"]["id"]
+
+        if self.wt is None:
+            self.wt = await self.get_wt()
+
+        account = await self.get_account_details(self.account_id)
+        self.root_folder_id = account["data"]["rootFolder"]
+        self.is_premium = account["data"]["tier"] != "standard"
+
+    @staticmethod
+    async def get_new_account() -> GetNewAccountResponse:
+        async with aiohttp.ClientSession() as session:
+            async with session.post("https://api.gofile.io/accounts") as resp:
+                response = await resp.json()
+                if "status" not in response or response["status"] != "ok":
+                    logger.error(pformat(response))
+                    raise Exception(response)
+                return response
+
+    def raise_error_if_not_premium_status(self):
+        if self.is_premium is False:
+            raise Exception(f"Account tier is standard but needs to be premium")
+
+    async def get_wt(self) -> Optional[str]:
+        # Maybe one day I'll figure out what this stands for
+        wt = None
+        async with aiohttp.ClientSession() as session:
+            async with session.get("https://gofile.io/dist/js/alljs.js") as resp:
+                response = await resp.text()
+                if self.options.get("debug_save_js_locally"):
+                    response_hash = hashlib.md5(response.encode("utf-8")).hexdigest()
+                    file_name = Path(f"gofile-alljs-{response_hash}.js")
+                    if file_name.exists():
+                        logger.debug(f"Gofile script {file_name} was retrieved but already existed locally")
+                    else:
+                        with open(file_name, "w") as file:
+                            file.write(response)
+                            logger.debug(f"Gofile script {file_name} was retrieved and saved locally")
+                wt_search = re.search(r"wt:\s*\"(\w{12})\"", response)
+                if wt_search:
+                    wt = wt_search.groups()[0]
+                    logger.debug(f"Gofile wt was successfully extracted as {wt}")
+                else:
+                    logger.error(f"Failed to fetch gofile wt")
+        return wt
+
+    async def get_servers(self, zone: Optional[Literal["eu", "na"]]) -> GetServersResponse:
+        params = {"zone": zone} if zone else None
+        async with self.session.get("/servers", params=params) as resp:
+            response = await resp.json()
+            if "status" not in response or response["status"] != "ok":
+                logger.error(pformat(response))
+                raise Exception(response)
+            return response
+
+    async def get_account_id(self) -> GetAccountIdResponse:
+        async with self.session.get("/accounts/getid") as resp:
+            response = await resp.json()
+            logger.debug(f'Account id is "{response["data"]["id"]}"')
+            return response
+
+    async def get_account_details(self, account_id: str) -> GetAccountDetailsResponse:
+        async with self.session.get(f"/accounts/{account_id}") as resp:
+            response = await resp.json()
+            logger.debug(f'Account details for "{account_id}" are {response["data"]}')
+            return response
+
+    async def set_premium_status(self) -> None:
+        account = await self.get_account_details(self.account_id)
+        self.is_premium = account["data"]["tier"] != "standard"
+
+    async def get_content(self, content_id: str, cache: Optional[bool], password: Optional[str]) -> GetContentResponse:
+        # Requires Premium or the whitelist token
+        if not self.wt:
+            self.raise_error_if_not_premium_status()
+
+        params = {}
+        if cache:
+            params["cache"] = "true"
+        if self.wt:
+            params["wt"] = self.wt
+        if password:
+            params["password"] = password
+
+        async with self.session.get(f"/contents/{content_id}", params=params) as resp:
+            response = await resp.json()
+            return response
+
+    async def create_folder(self, parent_folder_id: str, folder_name: Optional[str]) -> CreateFolderResponse:
+        data = {"parentFolderId": parent_folder_id}
+        if folder_name:
+            data["folderName"] = folder_name
+
+        logger.debug(f"Creating new folder '{folder_name}' in parent folder id '{parent_folder_id}' ")
+        async with self.session.post("/contents/createfolder", data=data) as resp:
+            response = await resp.json()
+            if "status" not in response or response["status"] != "ok":
+                raise Exception(response)
+            logger.debug(
+                f'Folder "{response["data"]["name"]}" ({response["data"]["folderId"]}) created in {response["data"]["parentFolder"]}'
+            )
+            self.created_folders[folder_name] = response["data"]
+            return response
+
+    async def update_content(
+        self, content_id: str, option: UpdateContentOption, value: UpdateContentOptionValue
+    ) -> UpdateContentResponse:
+        data = {"attribute": option, "attributeValue": value}
+        async with self.session.put(f"/contents/{content_id}/update", data=data) as resp:
+            response = await resp.json()
+            if "status" not in response or response["status"] != "ok":
+                raise Exception(response)
+            return response
+
+    async def delete_content(self, content_id: str) -> UpdateContentResponse:
+        async with self.session.delete(f"/contents/{content_id}") as resp:
+            response = await resp.json()
+            if "status" not in response or response["status"] != "ok":
+                raise Exception(response)
+            return response
+
+    async def delete_contents(self, content_ids: list[str]) -> DeleteContentsResponse:
+        data = {"contentsId": ",".join(content_ids)}
+        async with self.session.delete(f"/contents", data=data) as resp:
+            response = await resp.json()
+            if "status" not in response or response["status"] != "ok":
+                raise Exception(response)
+            return response
+
+    async def upload_file(self, file_path: Path, folder_id: Optional[str] = None) -> CompletedFileUploadResult:
+        if not file_path.exists():
+            raise Exception(f"File path {file_path} does not exist, cannot upload!")
+
+        if folder_id is None:
+            logger.warning(
+                "Uploading files without specifying folder ID, this will upload it to a randomly name folder. You most likely do not want to do this"
+            )
+
+        file_metadata = {
+            "filePath": str(file_path),
+            "filePathMD5": hashlib.md5(str(file_path).encode("utf-8")).hexdigest(),
+            "fileNameMD5": hashlib.md5(str(file_path.name).encode("utf-8")).hexdigest(),
+            "uploadSuccess": None,
+        }
+        async with self.sem:
+            retries = 0
+            while retries < self.options["retries"]:
+                try:
+                    # TODO: Rate limit to one request every 10 seconds
+                    servers = await self.get_servers(zone=self.options.get("zone"))
+
+                    server = next(iter(servers["data"]["servers"]))["name"]
+                    if server not in self.server_sessions:
+                        logger.info(f"Using new server connection to {server}")
+                        self.server_sessions[server] = aiohttp.ClientSession(
+                            f"https://{server}.gofile.io", headers=self.session_headers
+                        )
+
+                    session = self.server_sessions[server]
+
+                    # I couldn't get CallbackIOWrapper to work due to "Can not serialize value type: <class 'tqdm.utils.CallbackIOWrapper'>"
+                    # Maybe someone can try and get better results
+                    with TqdmUpTo(unit="B", unit_scale=True, unit_divisor=1024, miniters=1, desc=file_path.name) as t:
+                        with ProgressFileReader(filename=file_path, read_callback=t.update_to) as upload_file:
+                            data = aiohttp.FormData()
+                            data.add_field("file", upload_file, filename=file_path.name)
+                            logger.debug(f'File "{file_path.name}" was selected for upload')
+                            if folder_id:
+                                logger.debug(f'File {file_path.name} will be uploaded to folder id "{folder_id}"')
+                                data.add_field("folderId", folder_id)
+                            else:
+                                logger.debug(
+                                    f"File {file_path.name} will be uploaded to a new randomly created folder id"
+                                )
+
+                            async with session.post("/contents/uploadfile", data=data) as resp:
+                                response = await resp.json()
+                                if "status" not in response or response["status"] != "ok":
+                                    raise Exception(
+                                        f'File {file_path.name} failed upload load due to missing or not "ok" status in response:\n{pformat(response)}'
+                                    )
+                                file_metadata.update(response["data"])
+                                file_metadata["uploadSuccess"] = response.get("status")
+                                if file_metadata["uploadSuccess"] == "ok":
+                                    self.options["history"]["uploads"].append(file_metadata)
+                                return file_metadata
+
+                except Exception as e:
+                    retries += 1
+                    logger.error(f"Failed to upload {file_path} due to:\n", exc_info=e)
+
+                return file_metadata
+
+    async def upload_files(self, paths: List[Path], folder_id: Optional[str] = None) -> List[CompletedFileUploadResult]:
+        tasks = [self.upload_file(test_file, folder_id) for i, test_file in enumerate(paths)]
+        responses = await tqdm_asyncio.gather(*tasks, desc="Files uploaded")
+        return responses

--- a/src/gofile_uploader/cli.py
+++ b/src/gofile_uploader/cli.py
@@ -44,7 +44,7 @@ def cli() -> GofileUploaderOptions:
         "debug_save_js_locally": False,
     }
     parser = argparse.ArgumentParser(prog="gofile-upload", description="Gofile.io Uploader supporting parallel uploads")
-    parser.add_argument("file", type=Path, help="File or directory to look for files in to upload")
+    parser.add_argument("file", type=Path, help="File or example_files to look for files in to upload")
     parser.add_argument(
         "-t",
         "--token",
@@ -61,7 +61,7 @@ def cli() -> GofileUploaderOptions:
         help="Server zone to prefer uploading to",
     )
     parser.add_argument(
-        "-f", "--folder", type=str, help="Folder to upload files to overriding the directory name if used"
+        "-f", "--folder", type=str, help="Folder to upload files to overriding the example_files name if used"
     )
     parser.add_argument(
         "-d",

--- a/src/gofile_uploader/conftest.py
+++ b/src/gofile_uploader/conftest.py
@@ -1,0 +1,175 @@
+import asyncio
+import logging
+import os
+from copy import deepcopy
+from pathlib import Path
+from pprint import pprint
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from src.gofile_uploader.api import GofileIOAPI
+from src.gofile_uploader.gofile_uploader import GofileIOUploader
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
+
+BASE_CONFIG = {
+    "token": None,
+    "zone": None,
+    "connections": 1,
+    "public": False,
+    "save": False,
+    "retries": 1,
+    "history": {
+        "md5_sums": {},
+        "uploads": [],
+    },
+    "dry_run": False,
+    "debug_save_js_locally": False,
+    "use_config": False,
+    "folder": None,
+    "file": Path("src/gofile_uploader/tests/example_files/file1.txt"),
+    "config_file_path": None,
+    "config_directory": None,
+}
+
+
+@pytest.fixture(scope="session")
+def event_loop(request):
+    loop = asyncio.get_event_loop_policy().get_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="session")
+def base_cli_config():
+    return deepcopy(BASE_CONFIG)
+
+
+@pytest_asyncio.fixture(scope="session")
+async def base_cli_config_api(base_cli_config):
+    api = GofileIOAPI(base_cli_config)
+    yield api
+    if not api.session.closed:
+        await api.session.close()
+
+
+@pytest_asyncio.fixture(scope="session")
+async def base_cli_config_api_debug_save_js_locally(base_cli_config):
+    config = deepcopy(base_cli_config)
+    config["debug_save_js_locally"] = True
+
+    api = GofileIOAPI(config)
+    yield api
+    if not api.session.closed:
+        await api.session.close()
+
+
+# FIXME: No idea why but setting a scope on this will fail and complain about scope mismatch if I don't mark the test
+#  with the session scope or if I try to reuse the base_cli_config fixture
+#  The different scopes for asyncio seems like a known pain point from devs
+#  https://stackoverflow.com/questions/63713575/pytest-issues-with-a-session-scoped-fixture-and-asyncio
+#  https://github.com/pytest-dev/pytest-asyncio/issues/744
+#  https://github.com/pytest-dev/pytest-asyncio/issues/706
+@pytest_asyncio.fixture(scope="session")
+async def base_cli_config_api_with_account():
+    existing_api_key = os.environ.get("GOFILE_TOKEN")
+    if existing_api_key:
+        token = existing_api_key.strip()
+    else:
+        new_account = await GofileIOAPI.get_new_account()
+        token = new_account["data"]["token"]
+
+    config = deepcopy(BASE_CONFIG)
+
+    config["token"] = token
+    api = GofileIOAPI(config)
+
+    yield api
+    if not api.session.closed:
+        await api.session.close()
+
+
+@pytest_asyncio.fixture(scope="session")
+async def base_cli_config_api_with_account_initialized():
+    existing_api_key = os.environ.get("GOFILE_TOKEN")
+    if existing_api_key:
+        token = existing_api_key.strip()
+    else:
+        new_account = await GofileIOAPI.get_new_account()
+        token = new_account["data"]["token"]
+
+    config = deepcopy(BASE_CONFIG)
+
+    config["token"] = token
+    api = GofileIOAPI(config)
+    await api.init()
+
+    yield api
+
+    root_folder_contents = await api.get_content(api.root_folder_id, None, None)
+    root_folder_items: list[str] = root_folder_contents["data"]["childrenIds"]  # type: ignore
+    if root_folder_items:
+        await api.delete_contents(root_folder_items)
+
+    if not api.session.closed:
+        await api.session.close()
+
+    for server_session in api.server_sessions.values():
+        if not server_session.closed:
+            await server_session.close()
+
+
+@pytest_asyncio.fixture(scope="session")
+async def folder_from_account(base_cli_config_api_with_account_initialized):
+    api = base_cli_config_api_with_account_initialized
+    folder_name = str(uuid4())
+    create_folder_response = await api.create_folder(api.root_folder_id, folder_name)
+    yield create_folder_response["data"]
+    # No need to cleanup, base_cli_config_api_with_account_initialized does this for us
+
+
+@pytest_asyncio.fixture(scope="session")
+async def file_in_folder(base_cli_config_api_with_account_initialized, folder_from_account):
+    api = base_cli_config_api_with_account_initialized
+
+    file_path = Path("src/gofile_uploader/tests/example_files/file1.txt")
+    content_id = folder_from_account["folderId"]
+
+    file_uploaded = await api.upload_file(file_path, content_id)
+    yield file_uploaded
+
+
+@pytest_asyncio.fixture(scope="session")
+async def client_with_folder_and_file(base_cli_config):
+    config = deepcopy(base_cli_config)
+
+    existing_api_key = os.environ.get("GOFILE_TOKEN")
+    if existing_api_key:
+        token = existing_api_key.strip()
+    else:
+        new_account = await GofileIOAPI.get_new_account()
+        token = new_account["data"]["token"]
+
+    config["token"] = token
+
+    client = GofileIOUploader(config)
+    await client.api.init()
+
+    folder_name = str("test_folder")
+    create_folder_response = await client.api.create_folder(client.api.root_folder_id, folder_name)
+    file_path = Path("src/gofile_uploader/tests/example_files/file1.txt")
+
+    file_uploaded = await client.api.upload_file(file_path, create_folder_response["data"]["folderId"])
+
+    data = {"client": client, "folder": create_folder_response, "file": file_uploaded}
+
+    yield data
+
+    root_folder_contents = await client.api.get_content(client.api.root_folder_id, None, None)
+    root_folder_items: list[str] = root_folder_contents["data"]["childrenIds"]  # type: ignore
+    if root_folder_items:
+        await client.api.delete_contents(root_folder_items)
+    await client.cleanup_api_sessions()

--- a/src/gofile_uploader/gofile_uploader.py
+++ b/src/gofile_uploader/gofile_uploader.py
@@ -6,228 +6,17 @@ import logging
 import re
 import time
 from pathlib import Path
-from pprint import pformat, pprint
-from typing import Literal, Optional
+from pprint import pprint
 
-import aiohttp
-from tqdm.asyncio import tqdm_asyncio
+from typing_extensions import List, Optional
 
+from .api import GofileIOAPI
 from .cli import cli
-from .types import (
-    CompletedFileUploadResult,
-    CreateFolderData,
-    GetAccountDetailsResponse,
-    GetAccountIdResponse,
-    GetContentResponse,
-    GetServersResponse,
-    GofileUploaderOptions,
-    UpdateContentOption,
-    UpdateContentOptionValue,
-)
-from .utils import ProgressFileReader, TqdmUpTo, return_dict_without_none_value_keys
+from .types import CompletedFileUploadResult, GofileUploaderOptions
+from .utils import return_dict_without_none_value_keys
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
-
-
-class GofileIOAPI:
-    def __init__(self, options: GofileUploaderOptions):
-        self.options = options
-        self.session_headers = (
-            {"Authorization": f"Bearer {self.options['token']}"} if self.options.get("token") else None
-        )
-        self.session = aiohttp.ClientSession("https://api.gofile.io", headers=self.session_headers)
-        # These are set once the account is queried
-        self.root_folder_id = None
-        self.account_id = None
-        self.is_premium = False
-
-        self.wt = None
-        self.server_sessions = {}
-        self.created_folders = {}
-        self.sem = asyncio.Semaphore(self.options["connections"])
-
-    async def init(self):
-        account_id = await self.get_account_id()
-        self.account_id = account_id["data"]["id"]
-
-        if self.wt is None:
-            self.wt = await self.get_wt()
-
-        if self.options.get("token") is not None:
-            account = await self.get_account_details(self.account_id)
-            self.root_folder_id = account["data"]["rootFolder"]
-            self.is_premium = account["data"]["tier"] != "standard"
-
-    def check_public_account(self):
-        if self.options.get("token") is None:
-            raise Exception(f"Cannot perform functionality for public account, create and account and provide a token")
-
-    def check_premium_status(self):
-        self.check_public_account()
-        if self.is_premium is False:
-            raise Exception(f"Account tier is standard but needs to be premium")
-
-    async def get_wt(self) -> Optional[str]:
-        # Maybe one day I'll figure out what this stands for
-        wt = None
-        async with aiohttp.ClientSession() as session:
-            async with session.get("https://gofile.io/dist/js/alljs.js") as resp:
-                response = await resp.text()
-                if self.options.get("debug_save_js_locally"):
-                    response_hash = hashlib.md5(response.encode("utf-8")).hexdigest()
-                    file_name = Path(f"gofile-alljs-{response_hash}.js")
-                    if file_name.exists():
-                        logger.debug(f"Gofile script {file_name} was retrieved but already existed locally")
-                    else:
-                        with open(file_name, "w") as file:
-                            file.write(response)
-                            logger.debug(f"Gofile script {file_name} was retrieved and saved locally")
-                wt_search = re.search(r"wt:\s*\"(\w{12})\"", response)
-                if wt_search:
-                    wt = wt_search.groups()[0]
-                    logger.debug(f"Gofile wt was successfully extracted as {wt}")
-                else:
-                    logger.error(f"Failed to fetch gofile wt")
-        return wt
-
-    async def get_servers(self, zone: Optional[Literal["eu", "na"]]) -> GetServersResponse:
-        params = {"zone": zone} if zone else None
-        async with self.session.get("/servers", params=params) as resp:
-            response = await resp.json()
-            if "status" not in response or response["status"] != "ok":
-                logger.error(pformat(response))
-                raise Exception(response)
-            return response
-
-    async def get_account_id(self) -> GetAccountIdResponse:
-        self.check_public_account()
-        async with self.session.get("/accounts/getid") as resp:
-            response = await resp.json()
-            logger.debug(f'Account id is "{response["data"]["id"]}"')
-            return response
-
-    async def get_account_details(self, account_id: str) -> GetAccountDetailsResponse:
-        self.check_public_account()
-        async with self.session.get(f"/accounts/{account_id}") as resp:
-            response = await resp.json()
-            logger.debug(f'Account details for "{account_id}" are {response["data"]}')
-            return response
-
-    async def set_premium_status(self) -> None:
-        account = await self.get_account_details(self.account_id)
-        self.is_premium = account["data"]["tier"] != "standard"
-
-    async def get_content(self, content_id: str, cache: Optional[bool], password: Optional[str]) -> GetContentResponse:
-        # Requires Premium
-        if not self.wt:
-            self.check_premium_status()
-
-        params = {}
-        if cache:
-            params["cache"] = "true"
-        if self.wt:
-            params["wt"] = self.wt
-        if password:
-            params["password"] = password
-
-        async with self.session.get(f"/contents/{content_id}", params=params) as resp:
-            response = await resp.json()
-            return response
-
-    async def create_folder(self, parent_folder_id: str, folder_name: Optional[str]) -> CreateFolderData:
-        self.check_public_account()
-        data = {"parentFolderId": parent_folder_id}
-        if folder_name:
-            data["folderName"] = folder_name
-
-        logger.debug(f"Creating new folder '{folder_name}' in parent folder id '{parent_folder_id}' ")
-        async with self.session.post("/contents/createfolder", data=data) as resp:
-            response = await resp.json()
-            if "status" not in response or response["status"] != "ok":
-                raise Exception(response)
-            logger.debug(
-                f'Folder "{response["data"]["name"]}" ({response["data"]["folderId"]}) created in {response["data"]["parentFolder"]}'
-            )
-            self.created_folders[folder_name] = response["data"]
-            return response["data"]
-
-    async def update_content(
-        self, content_id: str, option: UpdateContentOption, value: UpdateContentOptionValue
-    ) -> CreateFolderData:
-        data = {"attribute": option, "attributeValue": value}
-        async with self.session.put(f"/contents/{content_id}/update", data=data) as resp:
-            response = await resp.json()
-            if "status" not in response or response["status"] != "ok":
-                raise Exception(response)
-            return response["data"]
-
-    async def upload_file(self, file_path: Path, folder_id: Optional[str] = None) -> CompletedFileUploadResult:
-        file_metadata = {
-            "filePath": str(file_path),
-            "filePathMD5": hashlib.md5(str(file_path).encode("utf-8")).hexdigest(),
-            "fileNameMD5": hashlib.md5(str(file_path.name).encode("utf-8")).hexdigest(),
-            "uploadSuccess": None,
-        }
-        async with self.sem:
-            retries = 0
-            while retries < self.options["retries"]:
-                try:
-                    # TODO: Rate limit to one request every 10 seconds
-                    servers = await self.get_servers(zone=self.options.get("zone"))
-
-                    server = next(iter(servers["data"]["servers"]))["name"]
-                    if server not in self.server_sessions:
-                        logger.info(f"Using new server connection to {server}")
-                        self.server_sessions[server] = aiohttp.ClientSession(
-                            f"https://{server}.gofile.io", headers=self.session_headers
-                        )
-
-                    session = self.server_sessions[server]
-
-                    # I couldn't get CallbackIOWrapper to work due to "Can not serialize value type: <class 'tqdm.utils.CallbackIOWrapper'>"
-                    # Maybe someone can try and get better results
-                    with TqdmUpTo(unit="B", unit_scale=True, unit_divisor=1024, miniters=1, desc=file_path.name) as t:
-                        with ProgressFileReader(filename=file_path, read_callback=t.update_to) as upload_file:
-                            data = aiohttp.FormData()
-                            data.add_field("file", upload_file, filename=file_path.name)
-                            logger.debug(f'File "{file_path.name}" was selected for upload')
-                            if folder_id:
-                                logger.debug(f'File {file_path.name} will be uploaded to folder id "{folder_id}"')
-                                data.add_field("folderId", folder_id)
-                            else:
-                                logger.debug(
-                                    f"File {file_path.name} will be uploaded to a new randomly created folder id"
-                                )
-
-                            async with session.post("/contents/uploadfile", data=data) as resp:
-                                response = await resp.json()
-                                if "status" not in response or response["status"] != "ok":
-                                    raise Exception(
-                                        f'File {file_path.name} failed upload load due to missing or not "ok" status in response:\n{pformat(response)}'
-                                    )
-                                file_metadata.update(response["data"])
-                                file_metadata["uploadSuccess"] = response.get("status")
-                                if file_metadata["uploadSuccess"] == "ok":
-                                    self.options["history"]["uploads"].append(file_metadata)
-                                return file_metadata
-
-                except Exception as e:
-                    retries += 1
-                    logger.error(f"Failed to upload {file_path} due to:\n", exc_info=e)
-
-                return file_metadata
-
-    async def upload_files(self, paths: list[Path], folder_id: Optional[str] = None) -> list[CompletedFileUploadResult]:
-        try:
-            tasks = [self.upload_file(test_file, folder_id) for i, test_file in enumerate(paths)]
-            responses = await tqdm_asyncio.gather(*tasks, desc="Files uploaded")
-            return responses
-        finally:
-            # This should happen in the API client itself
-            await self.session.close()
-            for server_session in self.server_sessions.values():
-                await server_session.close()
 
 
 class GofileIOUploader:
@@ -235,27 +24,17 @@ class GofileIOUploader:
         self.options = options
         self.api = GofileIOAPI(options)
 
-    async def init(self) -> None:
-        try:
-            if self.options.get("token") is not None:
-                await self.api.init()
-            # We should get the wt even if we don't have an account
-            if self.api.wt is None:
-                self.api.wt = await self.api.get_wt()
-
-        except Exception as ex:
-            logger.error(ex)
-            await self.api.session.close()
+    # TODO: Consider doing init in client instead of API
 
     def save_config_file(self):
         """
-        Creates the config directory and file with the current config options if using config is enabled
+        Creates the config example_files and file with the current config options if using config is enabled
         """
         if self.options.get("use_config"):
             config_directory = self.options["config_directory"]
             config_file_path = self.options["config_file_path"]
             if not config_directory.exists():
-                logger.info(f"Creating config directory at {config_directory}")
+                logger.info(f"Creating config example_files at {config_directory}")
                 config_directory.mkdir(parents=True, exist_ok=True)
 
             with open(config_file_path, "w") as config_file:
@@ -282,24 +61,15 @@ class GofileIOUploader:
         else:
             logger.error(f"Config file is not in use")
 
-    async def get_folder_id(self, folder: Optional[str]) -> Optional[str]:
+    async def get_folder_id(self, folder: Optional[str], cache: bool = True) -> str:
         """
         Get the id of a folder's name
         A folder should be the name of the folder you want to retrieve the id of but can also be the root id
         """
-
-        # No folder provided, try to use root folder
+        # No folder provided, use root folder (account now always exists since it will create one if none provided)
         if folder is None:
-            logger.warning("No folder was specified")
-            if self.options.get("token"):
-                # When no folder is specified and the user has an account, upload to the root folder
-                logger.debug("Using root folder id since we have an API token")
-                return self.api.root_folder_id
-            else:
-                logger.warning("Poorly supported: No API token exists, need to create an temporary account")
-                # TODO If the user has not specified a token for an account we should create an account on the fly so they
-                #  can keep all uploads in that folder
-                return None
+            logger.warning("No folder was specified, root folder id will be used")
+            return self.api.root_folder_id
         # Folder is UUIDv4, assume user is referencing to something already created
         elif re.match(r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}", folder):
             logger.warning(
@@ -307,16 +77,16 @@ class GofileIOUploader:
             )
             return folder
         # Folder needs to be created or already exists
-        elif self.options.get("token"):
-            root_folder_contents = await self.api.get_content(self.api.root_folder_id, cache=True, password=None)
+        else:
+            root_folder_contents = await self.api.get_content(self.api.root_folder_id, cache=cache, password=None)
 
-            # Another case that tbh don't name much sense but the user might specify "root" folder name which
+            # Another case that tbh don't make much sense but the user might specify "root" folder name which
             # is usually the root folder name
             if root_folder_contents["data"]["name"] == folder:
                 logger.info("The folder we wanted to create ended up being the account root folder")
                 return root_folder_contents["data"]["id"]
 
-            # Check in the root folder if there is a directory with that name already
+            # Check in the root folder if there is a example_files with that name already
             # We're only trying this one level deep otherwise we'd have to do recursive stuff I don't care to do atm
             folder_with_same_name = next(
                 (
@@ -337,12 +107,25 @@ class GofileIOUploader:
                     f'Could not find a folder inside the root folder with the name "{folder}" so we will create one'
                 )
                 new_folder = await self.api.create_folder(self.api.root_folder_id, folder)
-                return new_folder["folderId"]
-        else:
-            logger.warning("User did not provide an account or a folder name, should create temp account")
-            return None
+                return new_folder["data"]["folderId"]
 
-    def get_md5_sums_for_files(self, paths: list[Path]) -> dict[str, str]:
+    async def cleanup_api_sessions(self):
+        await self.api.session.close()
+        for server_session in self.api.server_sessions.values():
+            await server_session.close()
+        self.api.server_sessions.clear()
+
+    def save_responses_to_csv(self, responses: List[CompletedFileUploadResult]):
+        file_name = f"gofile_upload_{int(time.time())}.csv"
+        with open(file_name, "w", newline="") as csvfile:
+            logger.info(f"Saving uploaded files to {file_name}")
+            field_names = list(set().union(*[x.keys() for x in responses if x]))
+            csv_writer = csv.DictWriter(csvfile, dialect="excel", fieldnames=field_names)
+            csv_writer.writeheader()
+            for row in responses:
+                csv_writer.writerow(row)
+
+    def get_md5_sums_for_files(self, paths: List[Path]) -> dict[str, str]:
         sums = {}
 
         # TODO: Try to parallelize this
@@ -395,6 +178,7 @@ class GofileIOUploader:
             ]
 
             paths_and_md5_sums = self.get_md5_sums_for_files(paths)
+            # TODO: Rename files based on MD5sums
             paths_to_skip = [k for k, v in paths_and_md5_sums.items() if v in md5_sums_of_items_in_folder]
 
             if (
@@ -411,17 +195,14 @@ class GofileIOUploader:
             paths = [x for x in paths if str(x) not in paths_to_skip]
 
         if paths:
-            responses = await self.api.upload_files(paths, folder_id)
-            if self.options.get("save") and responses:
-                file_name = f"gofile_upload_{int(time.time())}.csv"
-                with open(file_name, "w", newline="") as csvfile:
-                    logger.info(f"Saving uploaded files to {file_name}")
-                    field_names = list(set().union(*[x.keys() for x in responses if x]))
-                    csv_writer = csv.DictWriter(csvfile, dialect="excel", fieldnames=field_names)
-                    csv_writer.writeheader()
-                    for row in responses:
-                        csv_writer.writerow(row)
+            try:
+                responses = await self.api.upload_files(paths, folder_id)
+            finally:
+                # FIXME: Should session management even be done here, probably not?
+                await self.cleanup_api_sessions()
 
+            if self.options.get("save") and responses:
+                self.save_responses_to_csv(responses)
             else:
                 pprint(responses)
         else:
@@ -435,14 +216,13 @@ async def async_main() -> None:
     gofile_client = GofileIOUploader(options)
 
     try:
-        await gofile_client.init()
+        await gofile_client.api.init()
         if options["dry_run"]:
             print("Dry run only, uploading skipped")
         else:
             await gofile_client.upload_files(options["file"], options.get("folder"))
     finally:
-        if not gofile_client.api.session.closed:
-            await gofile_client.api.session.close()
+        await gofile_client.cleanup_api_sessions()
         gofile_client.save_config_file()
 
 

--- a/src/gofile_uploader/tests/example_files/file1.txt
+++ b/src/gofile_uploader/tests/example_files/file1.txt
@@ -1,0 +1,1 @@
+hello world 1

--- a/src/gofile_uploader/tests/example_files/file2.txt
+++ b/src/gofile_uploader/tests/example_files/file2.txt
@@ -1,0 +1,1 @@
+hello world 2

--- a/src/gofile_uploader/tests/test_api_account.py
+++ b/src/gofile_uploader/tests/test_api_account.py
@@ -1,0 +1,56 @@
+from copy import deepcopy
+
+import pytest
+import pytest_asyncio
+from pydantic import TypeAdapter
+
+from src.gofile_uploader.api import GofileIOAPI
+from src.gofile_uploader.types import (
+    GetAccountDetailsResponse,
+    GetAccountIdResponse,
+    GetNewAccountResponse,
+)
+
+
+@pytest_asyncio.fixture(scope="function")
+async def base_cli_config_api_no_token(base_cli_config):
+    config = deepcopy(base_cli_config)
+
+    api = GofileIOAPI(config)
+    yield api
+    if not api.session.closed:
+        await api.session.close()
+
+
+class TestAPIAccount:
+    @pytest.mark.asyncio(scope="function")
+    async def test_init_api_with_no_token(self, base_cli_config_api_no_token):
+        api = base_cli_config_api_no_token
+        assert not api.options["token"]
+        await api.init()
+        assert api.options["token"]
+        assert api.account_id
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_get_new_account(self, base_cli_config_api):
+        api = base_cli_config_api
+        response = await api.get_new_account()
+        response_validator = TypeAdapter(GetNewAccountResponse)
+        response_validator.validate_python(response, strict=True, from_attributes=True)
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_get_account_id(self, base_cli_config_api_with_account):
+        api = base_cli_config_api_with_account
+        response = await api.get_account_id()
+        response_validator = TypeAdapter(GetAccountIdResponse)
+        response_validator.validate_python(response, strict=True, from_attributes=True)
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_get_account_details(self, base_cli_config_api_with_account):
+        api = base_cli_config_api_with_account
+
+        account_id_response = await api.get_account_id()
+
+        response = await api.get_account_details(account_id_response["data"]["id"])
+        response_validator = TypeAdapter(GetAccountDetailsResponse)
+        response_validator.validate_python(response, strict=True, from_attributes=True)

--- a/src/gofile_uploader/tests/test_api_folder.py
+++ b/src/gofile_uploader/tests/test_api_folder.py
@@ -1,0 +1,32 @@
+from uuid import uuid4
+
+import pytest
+from pydantic import TypeAdapter
+
+from src.gofile_uploader.types import CreateFolderResponse, UpdateContentResponse
+
+
+class TestAPIFolder:
+    @pytest.mark.asyncio(scope="session")
+    async def test_create_folder(self, base_cli_config_api_with_account_initialized):
+        api = base_cli_config_api_with_account_initialized
+
+        folder_name = uuid4()
+
+        response = await api.create_folder(api.root_folder_id, folder_name)
+        response_validator = TypeAdapter(CreateFolderResponse)
+        response_validator.validate_python(response, strict=True, from_attributes=True)
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_delete_folder(self, base_cli_config_api_with_account_initialized):
+        api = base_cli_config_api_with_account_initialized
+
+        folder_name = uuid4()
+
+        response = await api.create_folder(api.root_folder_id, folder_name)
+        response_validator = TypeAdapter(CreateFolderResponse)
+        response_validator.validate_python(response, strict=True, from_attributes=True)
+        delete_response = await api.delete_content(response["data"]["folderId"])
+
+        response_validator_delete = TypeAdapter(UpdateContentResponse)
+        response_validator_delete.validate_python(delete_response, strict=True, from_attributes=True)

--- a/src/gofile_uploader/tests/test_api_get_content.py
+++ b/src/gofile_uploader/tests/test_api_get_content.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from pydantic import TypeAdapter
+
+from src.gofile_uploader.types import GetContentResponse
+
+
+class TestAPIGetContent:
+    @pytest.mark.asyncio(scope="session")
+    async def test_get_folder_contents(
+        self, file_in_folder, folder_from_account, base_cli_config_api_with_account_initialized
+    ):
+        api = base_cli_config_api_with_account_initialized
+        file = file_in_folder
+        folder = folder_from_account
+
+        response = await api.get_content(file["parentFolder"], None, None)
+
+        response_validator = TypeAdapter(GetContentResponse)
+        response_validator.validate_python(response, strict=True, from_attributes=True)
+        assert response["data"]["name"] == folder["name"]
+        assert response["data"]["parentFolder"] == api.root_folder_id
+        assert response["data"]["type"] == "folder"
+        assert response["data"]["public"] is False
+        assert file["fileId"] in response["data"]["children"]
+        assert file["fileId"] in response["data"]["childrenIds"]
+        assert response["data"]["children"][file["fileId"]]["name"] == file["fileName"]
+        assert response["data"]["children"][file["fileId"]]["md5"] == file["md5"]
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_get_root_folder_contents(
+        self, file_in_folder, folder_from_account, base_cli_config_api_with_account_initialized
+    ):
+        api = base_cli_config_api_with_account_initialized
+        _file = file_in_folder
+        _folder = folder_from_account
+
+        response = await api.get_content(api.root_folder_id, None, None)
+
+        assert response["data"]["isRoot"]
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_get_file_contents(
+        self, file_in_folder, folder_from_account, base_cli_config_api_with_account_initialized
+    ):
+        api = base_cli_config_api_with_account_initialized
+        file = file_in_folder
+        folder = folder_from_account
+
+        response = await api.get_content(file["fileId"], None, None)
+
+        response_validator = TypeAdapter(GetContentResponse)
+        response_validator.validate_python(response, strict=True, from_attributes=True)
+        assert response["data"]["parentFolder"] == folder["folderId"]
+        assert response["data"]["type"] == "file"

--- a/src/gofile_uploader/tests/test_api_servers.py
+++ b/src/gofile_uploader/tests/test_api_servers.py
@@ -1,0 +1,24 @@
+import pytest
+from pydantic import TypeAdapter
+
+from src.gofile_uploader.types import GetServersResponse
+
+
+class TestAPIServers:
+    @pytest.mark.asyncio(scope="session")
+    async def test_get_servers(self, base_cli_config_api):
+        api = base_cli_config_api
+        response = await api.get_servers(None)
+        response_validator = TypeAdapter(GetServersResponse)
+        response_validator.validate_python(response, strict=True)
+
+    @pytest.mark.asyncio(scope="session")
+    @pytest.mark.skip(reason="The test makes sense but the code does not work like this")
+    async def test_get_servers_na(self, base_cli_config_api):
+        api = base_cli_config_api
+        region = "na"
+        response = await api.get_servers(region)
+        response_validator = TypeAdapter(GetServersResponse)
+        response_validator.validate_python(response, strict=True)
+        servers_with_undesired_regions = [x["zone"] for x in response["data"]["servers"]]
+        assert servers_with_undesired_regions == []

--- a/src/gofile_uploader/tests/test_api_update_content.py
+++ b/src/gofile_uploader/tests/test_api_update_content.py
@@ -1,0 +1,54 @@
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from pydantic import TypeAdapter
+
+from src.gofile_uploader.types import UpdateContentResponse
+
+
+class TestAPIUpdateContent:
+    @pytest.mark.asyncio(scope="session")
+    async def test_update_folder_rename(self, folder_from_account, base_cli_config_api_with_account_initialized):
+        api = base_cli_config_api_with_account_initialized
+
+        new_folder_name = uuid4()
+        content_id = folder_from_account["folderId"]
+        response = await api.update_content(content_id, "name", new_folder_name)
+        response_validator = TypeAdapter(UpdateContentResponse)
+        response_validator.validate_python(response, strict=True, from_attributes=True)
+
+    @pytest.mark.asyncio(scope="session")
+    @pytest.mark.parametrize("is_public", ["true", "false"])
+    async def test_update_folder_make_public(
+        self, folder_from_account, base_cli_config_api_with_account_initialized, is_public
+    ):
+        api = base_cli_config_api_with_account_initialized
+
+        content_id = folder_from_account["folderId"]
+        response = await api.update_content(content_id, "public", is_public)
+        response_validator = TypeAdapter(UpdateContentResponse)
+        response_validator.validate_python(response, strict=True, from_attributes=True)
+
+    @pytest.mark.parametrize("content_option", ["password", "description", "tags"])
+    @pytest.mark.asyncio(scope="session")
+    async def test_update_folder_set_password(
+        self, folder_from_account, base_cli_config_api_with_account_initialized, content_option
+    ):
+        api = base_cli_config_api_with_account_initialized
+
+        content_id = folder_from_account["folderId"]
+        # I'm being lazy and setting content value to the same things as the option
+        response = await api.update_content(content_id, content_option, content_option)
+        response_validator = TypeAdapter(UpdateContentResponse)
+        response_validator.validate_python(response, strict=True, from_attributes=True)
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_update_folder_set_expiry(self, folder_from_account, base_cli_config_api_with_account_initialized):
+        api = base_cli_config_api_with_account_initialized
+        expiry_date = int((datetime.today() + timedelta(days=1)).timestamp())
+
+        content_id = folder_from_account["folderId"]
+        response = await api.update_content(content_id, "expiry", expiry_date)
+        response_validator = TypeAdapter(UpdateContentResponse)
+        response_validator.validate_python(response, strict=True, from_attributes=True)

--- a/src/gofile_uploader/tests/test_api_upload_file.py
+++ b/src/gofile_uploader/tests/test_api_upload_file.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from pydantic import TypeAdapter
+from typing_extensions import List
+
+from src.gofile_uploader.types import CompletedFileUploadResult
+
+
+class TestAPIFolder:
+    @pytest.mark.asyncio(scope="session")
+    async def test_upload_file(self, base_cli_config_api_with_account_initialized):
+        api = base_cli_config_api_with_account_initialized
+
+        file_path = Path("src/gofile_uploader/tests/example_files/file1.txt")
+
+        response = await api.upload_file(file_path)
+        response_validator = TypeAdapter(CompletedFileUploadResult)
+        response_validator.validate_python(response, strict=True, from_attributes=True)
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_upload_file_to_folder(self, base_cli_config_api_with_account_initialized, folder_from_account):
+        api = base_cli_config_api_with_account_initialized
+
+        file_path = Path("src/gofile_uploader/tests/example_files/file1.txt")
+        content_id = folder_from_account["folderId"]
+
+        response = await api.upload_file(file_path, content_id)
+        response_validator = TypeAdapter(CompletedFileUploadResult)
+        response_validator.validate_python(response, strict=True, from_attributes=True)
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_upload_files(self, base_cli_config_api_with_account_initialized):
+        """
+        Because no folder id is specified these files will be uploaded to individual and randomly name folders of 6 chars
+        """
+        api = base_cli_config_api_with_account_initialized
+
+        file_paths = [
+            Path("src/gofile_uploader/tests/example_files/file1.txt"),
+            Path("src/gofile_uploader/tests/example_files/file2.txt"),
+        ]
+
+        response = await api.upload_files(file_paths)
+        response_validator = TypeAdapter(List[CompletedFileUploadResult])
+        response_validator.validate_python(response, strict=True, from_attributes=True)
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_upload_files_to_folder(self, base_cli_config_api_with_account_initialized):
+        api = base_cli_config_api_with_account_initialized
+
+        file_paths = [
+            Path("src/gofile_uploader/tests/example_files/file1.txt"),
+            Path("src/gofile_uploader/tests/example_files/file2.txt"),
+        ]
+
+        folder_name = str(uuid4())
+        create_folder_response = await api.create_folder(api.root_folder_id, folder_name)
+        content_id = create_folder_response["data"]["folderId"]
+
+        response = await api.upload_files(file_paths, content_id)
+        response_validator = TypeAdapter(List[CompletedFileUploadResult])
+        response_validator.validate_python(response, strict=True, from_attributes=True)

--- a/src/gofile_uploader/tests/test_api_wt.py
+++ b/src/gofile_uploader/tests/test_api_wt.py
@@ -1,0 +1,17 @@
+import re
+
+import pytest
+
+
+class TestAPIWT:
+    @pytest.mark.asyncio(scope="session")
+    async def test_get_whitelist_token(self, base_cli_config_api):
+        api = base_cli_config_api
+        response = await api.get_wt()
+        assert re.match(r"[a-zA-Z0-9]{12}", response)
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_get_whitelist_token_debug(self, base_cli_config_api_debug_save_js_locally):
+        api = base_cli_config_api_debug_save_js_locally
+        response = await api.get_wt()
+        assert re.match(r"[a-zA-Z0-9]{12}", response)

--- a/src/gofile_uploader/tests/test_client_folder.py
+++ b/src/gofile_uploader/tests/test_client_folder.py
@@ -1,0 +1,53 @@
+import time
+
+import pytest
+
+
+class TestClientFolder:
+    @pytest.mark.asyncio(scope="session")
+    async def test_get_folder_id_no_folder(self, client_with_folder_and_file):
+        # id as name and exists
+        # id as name but need creation
+        client = client_with_folder_and_file["client"]
+        folder = client_with_folder_and_file["folder"]
+        file = client_with_folder_and_file["file"]
+
+        folder_id = await client.get_folder_id(None)
+        assert folder_id == client.api.root_folder_id
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_get_folder_id_uuid_folder(self, client_with_folder_and_file):
+        # id as name and exists
+        # id as name but need creation
+        client = client_with_folder_and_file["client"]
+        folder = client_with_folder_and_file["folder"]
+        file = client_with_folder_and_file["file"]
+
+        folder_id = await client.get_folder_id(folder["data"]["folderId"])
+        assert folder_id == folder["data"]["folderId"]
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_get_folder_id_already_exists(self, client_with_folder_and_file):
+        # id as name and exists
+        # id as name but need creation
+        client = client_with_folder_and_file["client"]
+        folder = client_with_folder_and_file["folder"]
+        file = client_with_folder_and_file["file"]
+        # need to wait some time before server will see the folder as created
+        time.sleep(10)
+
+        folder_id = await client.get_folder_id(folder["data"]["name"], cache=False)
+        assert folder_id == folder["data"]["folderId"]
+
+    @pytest.mark.asyncio(scope="session")
+    async def test_get_folder_id_does_not_exist(self, client_with_folder_and_file):
+        # id as name and exists
+        # id as name but need creation
+        client = client_with_folder_and_file["client"]
+        folder = client_with_folder_and_file["folder"]
+        file = client_with_folder_and_file["file"]
+        # need to wait some time before server will see the folder as created
+        time.sleep(10)
+
+        folder_id = await client.get_folder_id("a_new_folder", cache=False)
+        assert folder_id != folder["data"]["folderId"]

--- a/src/gofile_uploader/types.py
+++ b/src/gofile_uploader/types.py
@@ -1,9 +1,26 @@
 from pathlib import Path
-from typing import Literal, Optional, TypedDict, Union
+
+from typing_extensions import (
+    Literal,
+    NotRequired,
+    Optional,
+    TypeAlias,
+    TypedDict,
+    Union,
+)
 
 
 class ServerResponse(TypedDict):
     status: str
+
+
+class GetNewAccountData(TypedDict):
+    id: str
+    token: str
+
+
+class GetNewAccountResponse(ServerResponse):
+    data: GetNewAccountData
 
 
 class CreateFolderData(TypedDict):
@@ -66,22 +83,25 @@ class GetAccountIdResponse(ServerResponse):
 
 
 class GetContentChildFile(TypedDict):
+    isOwner: bool
     id: str
-    type: str
+    parentFolder: str
+    type: Literal["folder", "file"]
     name: str
     createTime: int
     size: int
     downloadCount: int
     md5: str
     mimetype: str
+    servers: list[str]
     serverSelected: str
     link: str
-    thumbnail: str
+    thumbnail: NotRequired[str]
 
 
 class GetContentChildFolder(TypedDict):
     id: str
-    type: str
+    type: Literal["folder", "file"]
     name: str
     code: str
     createTime: int
@@ -89,24 +109,28 @@ class GetContentChildFolder(TypedDict):
     childrenIds: list[str]
 
 
-class GetContentData(TypedDict):
+class GetFolderContentData(TypedDict):
     isOwner: bool
     id: str
-    type: str
+    type: Literal["folder", "file"]
     name: str
+    createTime: int
     parentFolder: str
     code: str
-    createTime: int
-    isRoot: bool
     public: bool
     totalDownloadCount: int
     totalSize: int
     childrenIds: list[str]
     children: dict[str, Union[GetContentChildFile, GetContentChildFolder]]
+    # Only for root folder AFAICT
+    isRoot: NotRequired[bool]
+
+
+GetFileContentData: TypeAlias = GetContentChildFile
 
 
 class GetContentResponse(ServerResponse):
-    data: GetContentData
+    data: Union[GetFolderContentData, GetFileContentData]
 
 
 UpdateContentOption = Literal["name", "description", "tags", "public", "expiry", "password"]
@@ -135,6 +159,15 @@ class UploadFileData(TypedDict):
 
 class UploadFileResponse(ServerResponse):
     data: UploadFileData
+
+
+class UpdateContentResponse(ServerResponse):
+    # AFAICT This is always empty
+    data: dict
+
+
+class DeleteContentsResponse(ServerResponse):
+    data: dict[str, UpdateContentResponse]
 
 
 class CompletedFileUploadResult(UploadFileData):


### PR DESCRIPTION
- Added tests using pytest
  - New dev requirements: typing-extensions, pytest, pytest-asyncio, pydantic
- Split off Client and API into different classes
- Instructions for testing in README
- Added test coverage generation via pytest-cov
- Moved type imports such as `TypedDict` from `typing` to `typing_extensions`
- Added new `lint` rule to justfile
- Set version to development
- Create a temp account if no token is provided instead of trying to run in anon mode
- Cleanup some of the client inits and logic