### PR TITLE
Rename existing files if they exist on the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,10 +200,7 @@ You should disable this when debugging.
 
 # Improvements Wishlist
 - [ ] Paid accounts support, I don't have a paid account so I can't test
-- [ ] Update filenames during sync to local version
 - [ ] Add more tests
-- [ ] Create an account when the user does not do so
-- [ ] Add github runners for tests
 - [ ] Recursive directory upload support
 
 # Thanks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GofileIOUploader"
-version = "0.11.1.dev1"
+version = "0.11.1.dev2"
 description = "Gofile.io uploader supporting parallel uploads"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/gofile_uploader/api.py
+++ b/src/gofile_uploader/api.py
@@ -76,10 +76,15 @@ class GofileIOAPI:
         async with aiohttp.ClientSession() as session:
             async with session.post("https://api.gofile.io/accounts") as resp:
                 response = await resp.json()
-                if "status" not in response or response["status"] != "ok":
-                    logger.error(pformat(response))
-                    raise Exception(response)
+                GofileIOAPI.raise_error_if_error_in_remote_response(response)
                 return response
+
+    @staticmethod
+    def raise_error_if_error_in_remote_response(response):
+        if response and ("error" in response.get("status", "") or response.get("status", "") != "ok"):
+            msg = f"Failed getting response from server:\n{pformat(response)}"
+            logger.exception(msg)
+            raise Exception(msg)
 
     def raise_error_if_not_premium_status(self):
         if self.is_premium is False:
@@ -112,14 +117,13 @@ class GofileIOAPI:
         params = {"zone": zone} if zone else None
         async with self.session.get("/servers", params=params) as resp:
             response = await resp.json()
-            if "status" not in response or response["status"] != "ok":
-                logger.error(pformat(response))
-                raise Exception(response)
+            GofileIOAPI.raise_error_if_error_in_remote_response(response)
             return response
 
     async def get_account_id(self) -> GetAccountIdResponse:
         async with self.session.get("/accounts/getid") as resp:
             response = await resp.json()
+            GofileIOAPI.raise_error_if_error_in_remote_response(response)
             logger.debug(f'Account id is "{response["data"]["id"]}"')
             return response
 
@@ -158,8 +162,7 @@ class GofileIOAPI:
         logger.debug(f"Creating new folder '{folder_name}' in parent folder id '{parent_folder_id}' ")
         async with self.session.post("/contents/createfolder", data=data) as resp:
             response = await resp.json()
-            if "status" not in response or response["status"] != "ok":
-                raise Exception(response)
+            GofileIOAPI.raise_error_if_error_in_remote_response(response)
             logger.debug(
                 f'Folder "{response["data"]["name"]}" ({response["data"]["folderId"]}) created in {response["data"]["parentFolder"]}'
             )
@@ -172,23 +175,20 @@ class GofileIOAPI:
         data = {"attribute": option, "attributeValue": value}
         async with self.session.put(f"/contents/{content_id}/update", data=data) as resp:
             response = await resp.json()
-            if "status" not in response or response["status"] != "ok":
-                raise Exception(response)
+            GofileIOAPI.raise_error_if_error_in_remote_response(response)
             return response
 
     async def delete_content(self, content_id: str) -> UpdateContentResponse:
         async with self.session.delete(f"/contents/{content_id}") as resp:
             response = await resp.json()
-            if "status" not in response or response["status"] != "ok":
-                raise Exception(response)
+            GofileIOAPI.raise_error_if_error_in_remote_response(response)
             return response
 
     async def delete_contents(self, content_ids: list[str]) -> DeleteContentsResponse:
         data = {"contentsId": ",".join(content_ids)}
         async with self.session.delete(f"/contents", data=data) as resp:
             response = await resp.json()
-            if "status" not in response or response["status"] != "ok":
-                raise Exception(response)
+            GofileIOAPI.raise_error_if_error_in_remote_response(response)
             return response
 
     async def upload_file(self, file_path: Path, folder_id: Optional[str] = None) -> CompletedFileUploadResult:

--- a/src/gofile_uploader/api.py
+++ b/src/gofile_uploader/api.py
@@ -143,8 +143,12 @@ class GofileIOAPI:
             self.raise_error_if_not_premium_status()
 
         params = {}
-        if cache:
+        if cache is False:
+            params["cache"] = "false"
+        # Could also make this match against `is True` but maybe using cached responses is better
+        elif cache:
             params["cache"] = "true"
+
         if self.wt:
             params["wt"] = self.wt
         if password:

--- a/src/gofile_uploader/cli.py
+++ b/src/gofile_uploader/cli.py
@@ -42,6 +42,7 @@ def cli() -> GofileUploaderOptions:
         "retries": 3,
         "save": True,
         "debug_save_js_locally": False,
+        "rename_existing": True,
     }
     parser = argparse.ArgumentParser(prog="gofile-upload", description="Gofile.io Uploader supporting parallel uploads")
     parser.add_argument("file", type=Path, help="File or example_files to look for files in to upload")
@@ -73,6 +74,11 @@ def cli() -> GofileUploaderOptions:
         "--debug-save-js-locally",
         action=argparse.BooleanOptionalAction,
         help=f"Debug option to save the retrieved js file locally. (default: {default_cli_options['debug_save_js_locally']})",
+    )
+    parser.add_argument(
+        "--rename-existing",
+        action=argparse.BooleanOptionalAction,
+        help=f"If a file is already found on the remote server but the names differ, rename the file to its local name. (default: {default_cli_options['rename_existing']})",
     )
     parser.add_argument(
         "-c",

--- a/src/gofile_uploader/gofile_uploader.py
+++ b/src/gofile_uploader/gofile_uploader.py
@@ -168,7 +168,11 @@ class GofileIOUploader:
             if folder is None:
                 folder = path.name
         folder_id = await self.get_folder_id(folder)
+        paths_to_skip = []
+        renamed_files = []
 
+        # In the current state, a folder id should almost always exist because we're now creating accounts on init
+        # if one was not provided
         if folder_id:
             folder_id_contents = await self.api.get_content(folder_id, cache=True, password=None)
             # TODO: Consider more lightweight name-only matching instead of md5sum
@@ -178,8 +182,11 @@ class GofileIOUploader:
             ]
 
             paths_and_md5_sums = self.get_md5_sums_for_files(paths)
-            # TODO: Rename files based on MD5sums
-            paths_to_skip = [k for k, v in paths_and_md5_sums.items() if v in md5_sums_of_items_in_folder]
+
+            # Check which items should be skipped by checking their local and remote server md5sums
+            for local_file_path, local_file_md5sum in paths_and_md5_sums.items():
+                if local_file_md5sum in md5_sums_of_items_in_folder:
+                    paths_to_skip.append(local_file_path)
 
             if (
                 self.options["public"]
@@ -193,6 +200,36 @@ class GofileIOUploader:
                 f'{len(paths_to_skip)}/{len(paths)} files will be skipped since they were already uploaded to the folder "{folder}"'
             )
             paths = [x for x in paths if str(x) not in paths_to_skip]
+
+            # Here begins the code for renaming existing (matched by md5sum) files
+            for existing_file in paths_to_skip:
+                existing_file_md5 = paths_and_md5_sums[existing_file]
+                existing_file_name = Path(existing_file).name
+                # Technically multiple copies of the same file could be uploaded and need renaming
+                matching_remote_files_to_rename = [
+                    x
+                    for x in folder_id_contents["data"].get("children", {}).values()
+                    if x.get("type") == "file" and x.get("md5") == existing_file_md5 and existing_file_name != x["name"]
+                ]
+
+                if matching_remote_files_to_rename:
+                    logger.debug(
+                        f"File {existing_file} matched against md5 {existing_file_md5} on the server but with different name. Will renamed."
+                    )
+
+                for content_to_rename in matching_remote_files_to_rename:
+                    logger.info(f'Renaming {content_to_rename["name"]} (server) to {existing_file_name} (local)')
+                    try:
+                        await self.api.update_content(content_to_rename["id"], "name", existing_file_name)
+                        logger.exception(f'Renamed {content_to_rename["name"]} to {existing_file_name}')
+                    except Exception:
+                        logger.exception(
+                            f'Failed to rename file from {content_to_rename["name"]} (server) to {existing_file_name} (local)'
+                        )
+
+                    renamed_files.append(content_to_rename)
+
+        logger.info(f"Renamed {len(renamed_files)}/{len(paths_to_skip)} skipped files")
 
         if paths:
             try:

--- a/src/gofile_uploader/tests/test_client_folder.py
+++ b/src/gofile_uploader/tests/test_client_folder.py
@@ -33,8 +33,6 @@ class TestClientFolder:
         client = client_with_folder_and_file["client"]
         folder = client_with_folder_and_file["folder"]
         file = client_with_folder_and_file["file"]
-        # need to wait some time before server will see the folder as created
-        time.sleep(10)
 
         folder_id = await client.get_folder_id(folder["data"]["name"], cache=False)
         assert folder_id == folder["data"]["folderId"]
@@ -46,8 +44,6 @@ class TestClientFolder:
         client = client_with_folder_and_file["client"]
         folder = client_with_folder_and_file["folder"]
         file = client_with_folder_and_file["file"]
-        # need to wait some time before server will see the folder as created
-        time.sleep(10)
 
         folder_id = await client.get_folder_id("a_new_folder", cache=False)
         assert folder_id != folder["data"]["folderId"]

--- a/src/gofile_uploader/tests/test_client_upload.py
+++ b/src/gofile_uploader/tests/test_client_upload.py
@@ -1,0 +1,32 @@
+import pytest
+
+
+class TestClientUpload:
+    @pytest.mark.asyncio(scope="session")
+    async def test_existing_file_gets_renamed(
+        self, renamed_file_in_folder, folder_for_initialized_client, initialized_client
+    ):
+        # id as name and exists
+        # id as name but need creation
+        client = initialized_client
+        folder = folder_for_initialized_client
+        file = renamed_file_in_folder
+
+        folder_id = folder["data"]["folderId"]
+        assert client.options["rename_existing"]
+
+        folder_contents = await client.api.get_content(folder_id, None, None)
+        file_before_rename = [
+            x for x in folder_contents["data"]["children"].values() if x["md5"] == "35b783efece70cf246f5fa61ba9a4951"
+        ]
+        assert file_before_rename
+        await client.upload_files(client.options["file"], folder_id)
+
+        folder_contents_after = await client.api.get_content(folder_id, cache=False, password=None)
+        file_after_rename = [
+            x
+            for x in folder_contents_after["data"]["children"].values()
+            if x["md5"] == "35b783efece70cf246f5fa61ba9a4951"
+        ]
+        assert file_after_rename
+        assert file_after_rename[0]["name"] != file_before_rename[0]["name"]

--- a/src/gofile_uploader/types.py
+++ b/src/gofile_uploader/types.py
@@ -209,6 +209,7 @@ class GofileUploaderLocalConfigOptions(TypedDict):
 class GofileUploaderOptions(GofileUploaderLocalConfigOptions):
     dry_run: Optional[str]
     debug_save_js_locally: Optional[bool]
+    rename_existing: Optional[bool]
     use_config: Optional[bool]
     folder: Optional[str]
     file: Path


### PR DESCRIPTION
# New Features
- In addition to skipping an upload when an local md5 for a file is found on the remote server if the local file has a different name then it will be rename on the server.  
- This is controlled by the `--rename-existing` cli flag which is turned on by default

# Bugfixes
- Fixed issue where every content lookup was essentially cached