### PR TITLE
Improve Logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ classifiers = [
 dependencies = [
   "aiohttp",
   "tqdm",
+  "typing-extensions"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GofileIOUploader"
-version = "0.11.1.dev2"
+version = "0.12.0.dev1"
 description = "Gofile.io uploader supporting parallel uploads"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/gofile_uploader/api.py
+++ b/src/gofile_uploader/api.py
@@ -220,8 +220,12 @@ class GofileIOAPI:
                     server = next(iter(servers["data"]["servers"]))["name"]
                     if server not in self.server_sessions:
                         logger.info(f"Using new server connection to {server}")
+                        timeout = aiohttp.ClientTimeout(total=self.options["timeout"])
                         self.server_sessions[server] = aiohttp.ClientSession(
-                            f"https://{server}.gofile.io", headers=self.session_headers, raise_for_status=True
+                            f"https://{server}.gofile.io",
+                            headers=self.session_headers,
+                            raise_for_status=True,
+                            timeout=timeout,
                         )
 
                     session = self.server_sessions[server]

--- a/src/gofile_uploader/api.py
+++ b/src/gofile_uploader/api.py
@@ -26,7 +26,7 @@ from .types import (
 from .utils import ProgressFileReader, TqdmUpTo
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG)
+# logging.basicConfig(level=logging.INFO)
 
 
 class GofileIOAPI:

--- a/src/gofile_uploader/api.py
+++ b/src/gofile_uploader/api.py
@@ -26,7 +26,6 @@ from .types import (
 from .utils import ProgressFileReader, TqdmUpTo
 
 logger = logging.getLogger(__name__)
-# logging.basicConfig(level=logging.INFO)
 
 
 class GofileIOAPI:

--- a/src/gofile_uploader/cli.py
+++ b/src/gofile_uploader/cli.py
@@ -8,7 +8,6 @@ from .types import GofileUploaderLocalConfigOptions, GofileUploaderOptions
 from .utils import return_dict_without_none_value_keys
 
 logger = logging.getLogger(__name__)
-# logging.basicConfig(level=logging.INFO)
 
 
 def load_config_file(config_file_path: Path) -> GofileUploaderLocalConfigOptions:
@@ -47,7 +46,7 @@ def cli() -> GofileUploaderOptions:
         "rename_existing": True,
         # These options are not BooleanOptionalAction but I want them to always appear in the cli options dict
         "log_file": None,
-        "log_level": "info",
+        "log_level": "warning",
         "timeout": 600,
     }
     parser = argparse.ArgumentParser(prog="gofile-upload", description="Gofile.io Uploader supporting parallel uploads")

--- a/src/gofile_uploader/cli.py
+++ b/src/gofile_uploader/cli.py
@@ -23,6 +23,10 @@ def load_config_file(config_file_path: Path) -> GofileUploaderLocalConfigOptions
             try:
                 loaded_config = json.load(config_file)
                 config = {k: v for k, v in loaded_config.items() if v is not None}
+
+                # Special stuff to make the linter happy since JSON doesn't support all Python objects
+                if config.get("log_file"):
+                    config["log_file"] = Path(config["log_file"])
             except Exception as e:
                 logger.exception(
                     f"Failed to load config file {config_file_path} as a JSON config", stack_info=True, exc_info=e
@@ -32,7 +36,7 @@ def load_config_file(config_file_path: Path) -> GofileUploaderLocalConfigOptions
     return return_dict_without_none_value_keys(config)
 
 
-def cli() -> GofileUploaderOptions:
+def cli(argparse_arguments: list[str]) -> GofileUploaderOptions:
 
     # These are options that the CLI will default to when they have the BooleanOptionalAction action.
     # We do this because BooleanOptionalAction has 3 states of None/True/False which we need for the None value
@@ -129,7 +133,7 @@ def cli() -> GofileUploaderOptions:
         type=Path,
         help=f"Additional file to log information to. (default: {default_cli_options['log_file']})",
     )
-    args = parser.parse_args()
+    args = parser.parse_args(argparse_arguments)
 
     loaded_options = {}
 

--- a/src/gofile_uploader/cli.py
+++ b/src/gofile_uploader/cli.py
@@ -24,10 +24,12 @@ def load_config_file(config_file_path: Path) -> GofileUploaderLocalConfigOptions
             try:
                 loaded_config = json.load(config_file)
                 config = {k: v for k, v in loaded_config.items() if v is not None}
-            except Exception:
-                logger.exception(f"Failed to load config file {config_file_path} as a JSON config")
+            except Exception as e:
+                logger.exception(
+                    f"Failed to load config file {config_file_path} as a JSON config", stack_info=True, exc_info=e
+                )
     else:
-        logger.error(f"Could not load config file {config_file_path} because it did not exist")
+        logger.warning(f"Could not load config file {config_file_path} because it did not exist")
     return return_dict_without_none_value_keys(config)
 
 
@@ -43,6 +45,10 @@ def cli() -> GofileUploaderOptions:
         "save": True,
         "debug_save_js_locally": False,
         "rename_existing": True,
+        # These options are not BooleanOptionalAction but I want them to always appear in the cli options dict
+        "log_file": None,
+        "log_level": "info",
+        "timeout": 600,
     }
     parser = argparse.ArgumentParser(prog="gofile-upload", description="Gofile.io Uploader supporting parallel uploads")
     parser.add_argument("file", type=Path, help="File or example_files to look for files in to upload")
@@ -87,6 +93,11 @@ def cli() -> GofileUploaderOptions:
         help=f"Maximum parallel uploads to do at once. (default: {default_cli_options['connections']})",
     )
     parser.add_argument(
+        "--timeout",
+        type=int,
+        help=f"Number of seconds before aiohttp times out. If a single upload exceed this time it will fail. This will depend on internet speed but in best case scenario 5GB requires 300s. (default: {default_cli_options['timeout']})",
+    )
+    parser.add_argument(
         "--public",
         action=argparse.BooleanOptionalAction,
         help=f"Make all files uploaded public. By default they are private and not unsharable. (default: {default_cli_options['public']})",
@@ -109,11 +120,15 @@ def cli() -> GofileUploaderOptions:
         help=f"How many times to retry a failed upload. (default: {default_cli_options['retries']})",
     )
     parser.add_argument(
-        "--log",
+        "--log-level",
         type=str,
         choices=["debug", "info", "warning", "error", "critical"],
-        default="info",
-        help="Log level",
+        help=f"Log level. (default: {default_cli_options['log_level']})",
+    )
+    parser.add_argument(
+        "--log-file",
+        type=Path,
+        help=f"Additional file to log information to. (default: {default_cli_options['log_file']})",
     )
     args = parser.parse_args()
 

--- a/src/gofile_uploader/cli.py
+++ b/src/gofile_uploader/cli.py
@@ -8,7 +8,7 @@ from .types import GofileUploaderLocalConfigOptions, GofileUploaderOptions
 from .utils import return_dict_without_none_value_keys
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG)
+# logging.basicConfig(level=logging.INFO)
 
 
 def load_config_file(config_file_path: Path) -> GofileUploaderLocalConfigOptions:
@@ -107,6 +107,13 @@ def cli() -> GofileUploaderOptions:
         "--retries",
         type=int,
         help=f"How many times to retry a failed upload. (default: {default_cli_options['retries']})",
+    )
+    parser.add_argument(
+        "--log",
+        type=str,
+        choices=["debug", "info", "warning", "error", "critical"],
+        default="info",
+        help="Log level",
     )
     args = parser.parse_args()
 

--- a/src/gofile_uploader/conftest.py
+++ b/src/gofile_uploader/conftest.py
@@ -8,7 +8,7 @@ import pytest
 import pytest_asyncio
 
 from src.gofile_uploader.api import GofileIOAPI
-from src.gofile_uploader.gofile_uploader import GofileIOUploader
+from src.gofile_uploader.gofile_uploader import GofileIOUploader, cli
 
 BASE_CONFIG = {
     "token": None,
@@ -25,6 +25,9 @@ BASE_CONFIG = {
     "debug_save_js_locally": False,
     "rename_existing": True,
     "use_config": False,
+    "timeout": 600,
+    "log_level": "warning",
+    "log_file": None,
     "folder": None,
     "file": Path("src/gofile_uploader/tests/example_files/file1.txt"),
     "config_file_path": None,

--- a/src/gofile_uploader/conftest.py
+++ b/src/gofile_uploader/conftest.py
@@ -1,9 +1,7 @@
 import asyncio
-import logging
 import os
 from copy import deepcopy
 from pathlib import Path
-from pprint import pprint
 from uuid import uuid4
 
 import pytest
@@ -11,9 +9,6 @@ import pytest_asyncio
 
 from src.gofile_uploader.api import GofileIOAPI
 from src.gofile_uploader.gofile_uploader import GofileIOUploader
-
-logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG)
 
 BASE_CONFIG = {
     "token": None,

--- a/src/gofile_uploader/gofile_uploader.py
+++ b/src/gofile_uploader/gofile_uploader.py
@@ -175,7 +175,6 @@ class GofileIOUploader:
         # if one was not provided
         if folder_id:
             folder_id_contents = await self.api.get_content(folder_id, cache=True, password=None)
-            # TODO: Consider more lightweight name-only matching instead of md5sum
 
             md5_sums_of_items_in_folder = [
                 x["md5"] for x in folder_id_contents["data"].get("children", {}).values() if x.get("type") == "file"
@@ -224,11 +223,10 @@ class GofileIOUploader:
                         logger.info(f'Renaming {content_to_rename["name"]} (server) to {existing_file_name} (local)')
                         try:
                             await self.api.update_content(content_to_rename["id"], "name", existing_file_name)
-                            logger.exception(f'Renamed {content_to_rename["name"]} to {existing_file_name}')
-                        except Exception:
-                            logger.exception(
-                                f'Failed to rename file from {content_to_rename["name"]} (server) to {existing_file_name} (local)'
-                            )
+                            logger.info(f'Renamed {content_to_rename["name"]} to {existing_file_name}')
+                        except Exception as e:
+                            msg = f'Failed to rename file from {content_to_rename["name"]} (server) to {existing_file_name} (local)'
+                            logger.exception(msg, exc_info=e, stack_info=True)
 
                         renamed_files.append(content_to_rename)
 

--- a/src/gofile_uploader/gofile_uploader.py
+++ b/src/gofile_uploader/gofile_uploader.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import logging
 import re
+import sys
 import time
 from pathlib import Path
 from pprint import pformat, pprint
@@ -259,7 +260,7 @@ class GofileIOUploader:
 
 
 async def async_main() -> None:
-    options = cli()
+    options = cli(sys.argv[1:])
 
     logging_level = getattr(logging, options["log_level"].upper())
     handlers = [logging.StreamHandler()]

--- a/src/gofile_uploader/gofile_uploader.py
+++ b/src/gofile_uploader/gofile_uploader.py
@@ -6,7 +6,7 @@ import logging
 import re
 import time
 from pathlib import Path
-from pprint import pprint
+from pprint import pformat, pprint
 
 from typing_extensions import List, Optional
 
@@ -16,7 +16,7 @@ from .types import CompletedFileUploadResult, GofileUploaderOptions
 from .utils import return_dict_without_none_value_keys
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG, filename="gofile_uploader.log", encoding="utf-8")
 
 
 class GofileIOUploader:
@@ -59,7 +59,7 @@ class GofileIOUploader:
                 config = return_dict_without_none_value_keys(savable_config)
                 json.dump(config, config_file, indent=2)
         else:
-            logger.error(f"Config file is not in use")
+            logger.warning(f"Config file is not in use, will not save locally")
 
     async def get_folder_id(self, folder: Optional[str], cache: bool = True) -> str:
         """
@@ -251,7 +251,12 @@ class GofileIOUploader:
 
 async def async_main() -> None:
     options = cli()
-    logger.debug(options)
+
+    # This probably works even though it's done twice
+    logging_level = getattr(logging, options["log"].upper())
+    logging.basicConfig(level=logging_level)
+
+    logger.debug(pformat(options))
 
     gofile_client = GofileIOUploader(options)
 

--- a/src/gofile_uploader/gofile_uploader.py
+++ b/src/gofile_uploader/gofile_uploader.py
@@ -16,7 +16,6 @@ from .types import CompletedFileUploadResult, GofileUploaderOptions
 from .utils import return_dict_without_none_value_keys
 
 logger = logging.getLogger(__name__)
-# logging.basicConfig(level=logging.DEBUG, filename="gofile_uploader.log", encoding="utf-8")
 
 
 class GofileIOUploader:

--- a/src/gofile_uploader/tests/test_cli.py
+++ b/src/gofile_uploader/tests/test_cli.py
@@ -15,14 +15,14 @@ class TestClientCLI:
         assert len(loaded_config) == 0
 
     def test_cli_defaults(self):
-        args = ["src/gofile_uploader/tests/example_files/file1.txt", "--no-use-config"]
+        args = ["src/gofile_uploader/tests/example_files/file1.txt", "--no-use-config", "--token=123"]
         default_options = cli(args)
         assert default_options
 
         response_validator = TypeAdapter(GofileUploaderOptions)
 
         try:
-            # This is a massive pain to debug because exceptions get cutoff
+            # This is a pain to debug because exception messages get cutoff
             response_validator.validate_python(default_options, strict=True, from_attributes=True)
         except ValidationError as exc:
             pprint(repr(exc.errors()))

--- a/src/gofile_uploader/tests/test_cli.py
+++ b/src/gofile_uploader/tests/test_cli.py
@@ -1,7 +1,8 @@
 from pathlib import Path
+from pprint import pprint
 from uuid import uuid4
 
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
 from src.gofile_uploader.cli import cli, load_config_file
 from src.gofile_uploader.types import GofileUploaderOptions
@@ -19,7 +20,13 @@ class TestClientCLI:
         assert default_options
 
         response_validator = TypeAdapter(GofileUploaderOptions)
-        response_validator.validate_python(default_options, strict=True, from_attributes=True)
+
+        try:
+            # This is a massive pain to debug because exceptions get cutoff
+            response_validator.validate_python(default_options, strict=True, from_attributes=True)
+        except ValidationError as exc:
+            pprint(repr(exc.errors()))
+            raise exc
 
         assert default_options["config_file_path"] is None
         assert default_options["config_directory"] is None

--- a/src/gofile_uploader/tests/test_cli.py
+++ b/src/gofile_uploader/tests/test_cli.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from uuid import uuid4
+
+from pydantic import TypeAdapter
+
+from src.gofile_uploader.cli import cli, load_config_file
+from src.gofile_uploader.types import GofileUploaderOptions
+
+
+class TestClientCLI:
+    def test_load_config_enabled_but_missing(self):
+        config_name = Path(f"config_{uuid4()}.json")
+        loaded_config = load_config_file(config_name)
+        assert len(loaded_config) == 0
+
+    def test_cli_defaults(self):
+        args = ["src/gofile_uploader/tests/example_files/file1.txt", "--no-use-config"]
+        default_options = cli(args)
+        assert default_options
+
+        response_validator = TypeAdapter(GofileUploaderOptions)
+        response_validator.validate_python(default_options, strict=True, from_attributes=True)
+
+        assert default_options["config_file_path"] is None
+        assert default_options["config_directory"] is None
+        assert default_options["connections"] == 6
+        assert default_options["public"] is False
+        assert default_options["retries"] == 3
+        assert default_options["save"] is True
+        assert default_options["debug_save_js_locally"] is False
+        assert default_options["rename_existing"] is True
+        assert default_options["log_level"] == "warning"
+        assert default_options["timeout"] == 600
+        assert default_options["file"] == Path("src/gofile_uploader/tests/example_files/file1.txt")
+        assert default_options["dry_run"] is False
+        assert default_options["use_config"] is False
+
+        assert default_options["history"]
+        assert "md5_sums" in default_options["history"]
+        assert "uploads" in default_options["history"]
+        assert not default_options["history"]["md5_sums"]
+        assert not default_options["history"]["uploads"]

--- a/src/gofile_uploader/types.py
+++ b/src/gofile_uploader/types.py
@@ -213,6 +213,7 @@ class GofileUploaderOptions(GofileUploaderLocalConfigOptions):
     use_config: Optional[bool]
     folder: Optional[str]
     file: Path
+    log: Literal["debug", "info", "warning", "error", "critical"]
     # These options are derived on runtime
     config_file_path: Optional[Path]
     config_directory: Optional[Path]

--- a/src/gofile_uploader/types.py
+++ b/src/gofile_uploader/types.py
@@ -213,7 +213,9 @@ class GofileUploaderOptions(GofileUploaderLocalConfigOptions):
     use_config: Optional[bool]
     folder: Optional[str]
     file: Path
-    log: Literal["debug", "info", "warning", "error", "critical"]
+    log_level: Literal["debug", "info", "warning", "error", "critical"]
+    log_file: Optional[Path]
+    timeout: int
     # These options are derived on runtime
     config_file_path: Optional[Path]
     config_directory: Optional[Path]

--- a/src/gofile_uploader/types.py
+++ b/src/gofile_uploader/types.py
@@ -198,7 +198,7 @@ class GofileUploaderLocalConfigHistory(TypedDict):
 
 class GofileUploaderLocalConfigOptions(TypedDict):
     token: Optional[str]
-    zone: Optional[str]
+    zone: NotRequired[Optional[str]]
     connections: Optional[int]
     public: Optional[bool]
     save: Optional[bool]
@@ -207,11 +207,11 @@ class GofileUploaderLocalConfigOptions(TypedDict):
 
 
 class GofileUploaderOptions(GofileUploaderLocalConfigOptions):
-    dry_run: Optional[str]
+    dry_run: Optional[bool]
     debug_save_js_locally: Optional[bool]
     rename_existing: Optional[bool]
     use_config: Optional[bool]
-    folder: Optional[str]
+    folder: NotRequired[Optional[str]]
     file: Path
     log_level: Literal["debug", "info", "warning", "error", "critical"]
     log_file: Optional[Path]


### PR DESCRIPTION
# Logging

Improvements for logging such as:
- Better messages, levels, and print statements
- CLI options for
  - log level
  - log file (console logging will always be done)

# Fixes for:
- aiohttp timeout over 5min (300s) per file https://github.com/alexmi256/gofile-uploader/issues/6
  - Users can now specify an aiohttp timeout and I've increased the default of 300s to 600s

# Other Stuff
- Adds `typing-externions` requirement instead of the default Python ones for improved consistency and backwards compatibility
- Sets version to `0.12.0.dev1` due to new features and changes instead of just minor patches
- Introduced kinda weird behavior with logging and config file. Once you've set a log file path this will be saved to your local gofile config. While this can be nice to not have to re-specify, there is no way via CLI to remove it. May be annoying for others.