### PR TITLE
Add recursive (glob) file upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GofileIOUploader"
-version = "0.12.1"
+version = "0.12.2"
 description = "Gofile.io uploader supporting parallel uploads"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/gofile_uploader/cli.py
+++ b/src/gofile_uploader/cli.py
@@ -52,6 +52,7 @@ def cli(argparse_arguments: list[str]) -> GofileUploaderOptions:
         "log_file": None,
         "log_level": "warning",
         "timeout": 600,
+        "recurse_directories": False,
     }
     parser = argparse.ArgumentParser(prog="gofile-upload", description="Gofile.io Uploader supporting parallel uploads")
     parser.add_argument("file", type=Path, help="File or directory to look for files in to upload")
@@ -115,6 +116,16 @@ def cli(argparse_arguments: list[str]) -> GofileUploaderOptions:
         action=argparse.BooleanOptionalAction,
         default=True,
         help=f"Whether to create and use a config file in $HOME/.config/gofile_upload/config.json.",
+    )
+    parser.add_argument(
+        "--recurse-directories",
+        action=argparse.BooleanOptionalAction,
+        help=f"Whether to recursively iterate all directories and search for files to upload if a directory is given as the upload file",
+    )
+    parser.add_argument(
+        "--recurse-max",
+        default=1000,
+        help=f"Maximum number of files before the program errors out when using --recurse-directory feature. Put here as safety feature.",
     )
     parser.add_argument(
         "-r",

--- a/src/gofile_uploader/gofile_uploader.py
+++ b/src/gofile_uploader/gofile_uploader.py
@@ -167,7 +167,15 @@ class GofileIOUploader:
         if path.is_file():
             paths = [path]
         else:
-            paths = [x for x in path.iterdir()]
+            if self.options.get("recurse_directories"):
+                max_files_before_error = self.options["recurse_max"]
+                paths = [x for x in path.rglob("*") if x.is_file()]
+                if len(paths) > max_files_before_error:
+                    raise Exception(
+                        f'You are about to upload {len(paths)} files which is a lot. Are you sure you want to do this? If yes run again with the "--recurse-max={len(paths)}" flag.'
+                    )
+            else:
+                paths = [x for x in path.iterdir()]
             if folder is None:
                 folder = path.name
         folder_id = await self.get_folder_id(folder)

--- a/src/gofile_uploader/types.py
+++ b/src/gofile_uploader/types.py
@@ -218,6 +218,8 @@ class GofileUploaderLocalConfigOptions(TypedDict):
     save: Optional[bool]
     retries: Optional[int]
     history: GofileUploaderLocalConfigHistory
+    recurse_directories: Optional[bool]
+    recurse_max: Optional[int]
 
 
 class GofileUploaderOptions(GofileUploaderLocalConfigOptions):


### PR DESCRIPTION
Adds a flag (`--recurse-directories`) to recursively upload all files from a given path even if they reside within a directory themselves.
All files will be uploaded but in a flattened structure.
I've included the `--recurse-max` flag which defaults to 1000 as a safety measure so that you don't upload a whole drive unintentionally. If there are more files than recurse-max, the program will quit but this can be configured to any limit.