### PR TITLE
Improve ratelimiting, add recursive uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@ usage: gofile-upload [-h] [-t TOKEN] [-z {na,eu}] [-f FOLDER] [-d]
                      [--rename-existing | --no-rename-existing]
                      [-c CONNECTIONS] [--timeout TIMEOUT]
                      [--public | --no-public] [--save | --no-save]
-                     [--use-config | --no-use-config] [-r RETRIES]
+                     [--use-config | --no-use-config]
+                     [--recurse-directories | --no-recurse-directories]
+                     [--recurse-max RECURSE_MAX]
+                     [--exclude-file-types EXCLUDE_FILE_TYPES]
+                     [--only-file-types ONLY_FILE_TYPES] [-r RETRIES]
+                     [--hash-pool-size HASH_POOL_SIZE]
                      [--log-level {debug,info,warning,error,critical}]
                      [--log-file LOG_FILE]
                      file
@@ -67,8 +72,25 @@ optional arguments:
                         Whether to create and use a config file in
                         $HOME/.config/gofile_upload/config.json. (default:
                         True)
+  --recurse-directories, --no-recurse-directories
+                        Whether to recursively iterate all directories and
+                        search for files to upload if a directory is given as
+                        the upload file
+  --recurse-max RECURSE_MAX
+                        Maximum number of files before the program errors out
+                        when using --recurse-directory feature. Put here as
+                        safety feature.
+  --exclude-file-types EXCLUDE_FILE_TYPES
+                        Exclude files ending with these extensions from being
+                        uploaded. Comma separated values. Example: jpg,png
+  --only-file-types ONLY_FILE_TYPES
+                        Only upload files ending with these extensions. Comma
+                        separated values. Example: jpg,png
   -r RETRIES, --retries RETRIES
                         How many times to retry a failed upload. (default: 3)
+  --hash-pool-size HASH_POOL_SIZE
+                        How many md5 hashes to calculate in parallel.
+                        (default: 4)
   --log-level {debug,info,warning,error,critical}
                         Log level. (default: warning)
   --log-file LOG_FILE   Additional file to log information to. (default: None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GofileIOUploader"
-version = "0.12.6.dev7"
+version = "0.12.6.dev8"
 description = "Gofile.io uploader supporting parallel uploads"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GofileIOUploader"
-version = "0.12.6.dev6"
+version = "0.12.6.dev7"
 description = "Gofile.io uploader supporting parallel uploads"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GofileIOUploader"
-version = "0.12.6.dev1"
+version = "0.12.6.dev2"
 description = "Gofile.io uploader supporting parallel uploads"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GofileIOUploader"
-version = "0.12.6.dev2"
+version = "0.12.6.dev3"
 description = "Gofile.io uploader supporting parallel uploads"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GofileIOUploader"
-version = "0.12.6.dev8"
+version = "0.13.0"
 description = "Gofile.io uploader supporting parallel uploads"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GofileIOUploader"
-version = "0.12.5"
+version = "0.12.6.dev1"
 description = "Gofile.io uploader supporting parallel uploads"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GofileIOUploader"
-version = "0.12.6.dev5"
+version = "0.12.6.dev6"
 description = "Gofile.io uploader supporting parallel uploads"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GofileIOUploader"
-version = "0.12.6.dev4"
+version = "0.12.6.dev5"
 description = "Gofile.io uploader supporting parallel uploads"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GofileIOUploader"
-version = "0.12.6.dev3"
+version = "0.12.6.dev4"
 description = "Gofile.io uploader supporting parallel uploads"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/gofile_uploader/cli.py
+++ b/src/gofile_uploader/cli.py
@@ -53,7 +53,7 @@ def cli(argparse_arguments: list[str]) -> GofileUploaderOptions:
         "log_level": "warning",
         "timeout": 600,
         "recurse_directories": False,
-        "hash_pool_size": 4,
+        "hash_pool_size": max(os.cpu_count() - 2, 1),
     }
     parser = argparse.ArgumentParser(prog="gofile-upload", description="Gofile.io Uploader supporting parallel uploads")
     parser.add_argument("file", type=Path, help="File or directory to look for files in to upload")

--- a/src/gofile_uploader/cli.py
+++ b/src/gofile_uploader/cli.py
@@ -53,6 +53,7 @@ def cli(argparse_arguments: list[str]) -> GofileUploaderOptions:
         "log_level": "warning",
         "timeout": 600,
         "recurse_directories": False,
+        "hash_pool_size": 4,
     }
     parser = argparse.ArgumentParser(prog="gofile-upload", description="Gofile.io Uploader supporting parallel uploads")
     parser.add_argument("file", type=Path, help="File or directory to look for files in to upload")
@@ -143,6 +144,11 @@ def cli(argparse_arguments: list[str]) -> GofileUploaderOptions:
         "--retries",
         type=int,
         help=f"How many times to retry a failed upload. (default: {default_cli_options['retries']})",
+    )
+    parser.add_argument(
+        "--hash-pool-size",
+        type=int,
+        help=f"How many md5 hashes to calculate in parallel. (default: {default_cli_options['hash_pool_size']})",
     )
     parser.add_argument(
         "--log-level",

--- a/src/gofile_uploader/conftest.py
+++ b/src/gofile_uploader/conftest.py
@@ -30,6 +30,7 @@ BASE_CONFIG = {
     "log_file": None,
     "folder": None,
     "file": Path("src/gofile_uploader/tests/example_files/file1.txt"),
+    "hash_pool_size": 1,
     "config_file_path": None,
     "config_directory": None,
 }

--- a/src/gofile_uploader/gofile_uploader.py
+++ b/src/gofile_uploader/gofile_uploader.py
@@ -266,6 +266,7 @@ class GofileIOUploader:
                         try:
                             await self.api.update_content(content_to_rename["id"], "name", existing_file_name)
                             logger.info(f'Renamed {content_to_rename["name"]} to {existing_file_name}')
+                            time.sleep(0.5)
                         except Exception as e:
                             msg = f'Failed to rename file from {content_to_rename["name"]} (server) to {existing_file_name} (local)'
                             logger.exception(msg, exc_info=e, stack_info=True)

--- a/src/gofile_uploader/gofile_uploader.py
+++ b/src/gofile_uploader/gofile_uploader.py
@@ -114,7 +114,9 @@ class GofileIOUploader:
                     f'Could not find a folder inside the root folder with the name "{folder}" so we will create one'
                 )
                 if self.options["dry_run"]:
-                    print(f"Dry run only, skipping folder creation of '{folder}' and using root folder")
+                    print(
+                        f"Dry run only, skipping folder creation of '{folder}' and using root folder '{self.api.root_folder_id}'"
+                    )
                     return self.api.root_folder_id
                 else:
                     new_folder = await self.api.create_folder(self.api.root_folder_id, folder)
@@ -228,7 +230,7 @@ class GofileIOUploader:
                 else:
                     await self.api.update_content(folder_id, "public", "true")
 
-            skipped_files_msg = f'{len(paths_to_skip)}/{len(paths)} files will be skipped since they were already uploaded to the folder "{folder}"'
+            skipped_files_msg = f'{len(paths_to_skip)}/{len(paths)} files will be skipped since they were already uploaded to the folder "{folder}" ({folder_id})'
 
             logger.info(skipped_files_msg)
 

--- a/src/gofile_uploader/gofile_uploader.py
+++ b/src/gofile_uploader/gofile_uploader.py
@@ -147,7 +147,10 @@ class GofileIOUploader:
 
         number_of_files = len(paths_of_files)
 
-        logger.info(f"Calculating hashes for {number_of_files}/{len(paths)} files")
+        if number_of_files:
+            logger.info(f"Calculating hashes for {number_of_files}/{len(paths)} files")
+        else:
+            logger.info(f"All {len(paths)} files were previously hashed")
 
         with tqdm(
             total=number_of_files, desc="Hashes Calculated", disable=disable_hashing_progress
@@ -164,7 +167,7 @@ class GofileIOUploader:
         # Update the current configs since we could have calculated md5 sums
         self.save_config_file()
 
-        return {str(path): self.options["history"]["md5_sums"][str(path)] for path in paths_of_files}
+        return {str(path): self.options["history"]["md5_sums"][str(path)] for path in paths}
 
     @staticmethod
     def checksum(filename: Path, hash_factory=hashlib.md5, chunk_num_blocks: int = 128):

--- a/src/gofile_uploader/gofile_uploader.py
+++ b/src/gofile_uploader/gofile_uploader.py
@@ -9,6 +9,7 @@ import time
 from pathlib import Path
 from pprint import pformat, pprint
 
+from tqdm import tqdm
 from typing_extensions import List, Optional, cast
 
 from .api import GofileIOAPI
@@ -134,7 +135,8 @@ class GofileIOUploader:
         sums = {}
 
         # TODO: Try to parallelize this
-        for path in paths:
+        disable_hashing_progress = True if len(paths) < 50 else False
+        for path in tqdm(paths, desc="Hashes Calculated", disable=disable_hashing_progress):
             if path.is_file():
                 if str(path) in self.options["history"]["md5_sums"]:
                     md5_sum_for_file = self.options["history"]["md5_sums"][str(path)]

--- a/src/gofile_uploader/types.py
+++ b/src/gofile_uploader/types.py
@@ -220,6 +220,7 @@ class GofileUploaderLocalConfigOptions(TypedDict):
     history: GofileUploaderLocalConfigHistory
     recurse_directories: Optional[bool]
     recurse_max: Optional[int]
+    hash_pool_size: Optional[int]
 
 
 class GofileUploaderOptions(GofileUploaderLocalConfigOptions):


### PR DESCRIPTION
# Bugs and Debugging
Improves rate limiting and debugging by slowing down file renames and adding better `--dry-run` support.

# Recursive Uploads
Adds ability to upload all files in a directory by recursively finding files. 
All files will be uploaded into one directory and directory structure will be lost. 
Use `--recurse-directories` for this option in conjunction  `--exclude-file-types` or `--only-file-types` to limit the file types that you want to upload. This feature implements the `--recurse-max` flag as a safety measure so you don't upload a whole drive and has a default of 1000 files. 
If you go over this limit the program will just exit. If you need to upload more files than that you will need to set this flag.

# Parallel MD5 Hashing 
Also introduces the some md5sum hashing improvements (supposedly) by hashing in parallel with a default based on your CPU core count. This can be configured via `--hash-pool-size`. Needs more testing.