### PR TITLE
Fix packaging due to requirements twine

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,10 +3,11 @@ tqdm
 black
 isort
 pre-commit
-twine
+twine >=6.1.0
 build
 typing-extensions
 pytest
 pytest-asyncio
 pydantic
 pytest-cov
+packaging >= 24.2


### PR DESCRIPTION
Ran into https://github.com/pypa/twine/issues/1216 and https://github.com/astral-sh/rye/issues/1446
So this forces `twine` and `packaging` to a minimum version